### PR TITLE
feat(docs): add investigation document type

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -191,7 +191,7 @@ Add the new type to `DefaultConfig()`:
 
 ```go
 func ValidTypes() []string {
-    return []string{"rfc", "adr", "design", "impl", "plan"}
+    return []string{"rfc", "adr", "design", "impl", "investigation"}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ docs/impl/
 └── 0001-telemetry-pipeline-implementation.md
 ```
 
+### INV — Investigation
+
+Time-boxed research spikes and validation experiments. Use to answer a specific
+question before committing to a design or implementation — e.g. proving a
+library handles a requirement, reproducing a weird error, or validating a
+performance assumption. Design, plan, and impl docs can reference investigations
+by ID to document how open questions were resolved.
+
+```
+docs/investigation/
+└── 0001-can-pgvector-handle-concurrent-writes.md
+```
+
 ## Configuration
 
 `docz` reads configuration from two locations, deep-merged with repo taking
@@ -231,6 +244,17 @@ types:
       - Completed
       - Paused
       - Cancelled
+  investigation:
+    enabled: true
+    dir: investigation
+    id_prefix: INV
+    id_width: 4
+    statuses:
+      - Open
+      - In Progress
+      - Concluded
+      - Inconclusive
+      - Abandoned
 ```
 
 Run `docz config` to see the fully resolved configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,14 @@ func DefaultConfig() Config {
 				Statuses:    []string{"Draft", "In Progress", "Completed", "Paused", "Cancelled"},
 				StatusField: "status",
 			},
+			"investigation": {
+				Enabled:     true,
+				Dir:         "investigation",
+				IDPrefix:    "INV",
+				IDWidth:     4,
+				Statuses:    []string{"Open", "In Progress", "Concluded", "Inconclusive", "Abandoned"},
+				StatusField: "status",
+			},
 		},
 		Index: IndexConfig{
 			AutoUpdate:     true,
@@ -134,7 +142,7 @@ func (c *Config) TypeDir(docType string) string {
 
 // ValidTypes returns the list of built-in document type names.
 func ValidTypes() []string {
-	return []string{"rfc", "adr", "design", "impl"}
+	return []string{"rfc", "adr", "design", "impl", "investigation"}
 }
 
 // Validate checks the configuration for common errors and returns a list of

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,7 +43,7 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestValidTypes(t *testing.T) {
 	types := ValidTypes()
-	want := []string{"rfc", "adr", "design", "impl"}
+	want := []string{"rfc", "adr", "design", "impl", "investigation"}
 	if len(types) != len(want) {
 		t.Fatalf("ValidTypes() has %d elements, want %d", len(types), len(want))
 	}
@@ -100,8 +100,8 @@ func TestLoad_NoConfigFiles(t *testing.T) {
 	if cfg.DocsDir != "docs" {
 		t.Errorf("DocsDir = %q, want %q", cfg.DocsDir, "docs")
 	}
-	if len(cfg.Types) != 4 {
-		t.Errorf("expected 4 types, got %d", len(cfg.Types))
+	if len(cfg.Types) != 5 {
+		t.Errorf("expected 5 types, got %d", len(cfg.Types))
 	}
 }
 
@@ -141,8 +141,8 @@ author:
 		t.Error("Author.FromGit should be false")
 	}
 	// Types should still have defaults.
-	if len(cfg.Types) != 4 {
-		t.Errorf("expected 4 types, got %d", len(cfg.Types))
+	if len(cfg.Types) != 5 {
+		t.Errorf("expected 5 types, got %d", len(cfg.Types))
 	}
 }
 

--- a/internal/template/templates/index_investigation.md
+++ b/internal/template/templates/index_investigation.md
@@ -1,0 +1,12 @@
+# Investigations
+
+Time-boxed research spikes and validation experiments. Use an investigation
+doc to answer a specific question before committing to a design or
+implementation — e.g. proving a library can handle a requirement, reproducing
+a bug, or validating a performance assumption.
+
+Design docs, plans, and implementation docs can reference investigations by ID
+(e.g. `INV-0001`) to document how open questions were resolved.
+
+<!-- BEGIN DOCZ AUTO-GENERATED -->
+<!-- END DOCZ AUTO-GENERATED -->

--- a/internal/template/templates/investigation.md
+++ b/internal/template/templates/investigation.md
@@ -1,0 +1,76 @@
+---
+id: {{ .Prefix }}-{{ .Number }}
+title: "{{ .Title }}"
+status: {{ .Status }}
+author: {{ .Author }}
+created: {{ .Date }}
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV {{ .Number }}: {{ .Title }}
+
+**Status:** {{ .Status }}
+**Author:** {{ .Author }}
+**Date:** {{ .Date }}
+
+## Question
+
+<!-- What specific question are we trying to answer? Be precise — a good
+     investigation question has a clear yes/no or concrete answer.
+     Example: "Can we use X library to achieve Y without Z limitation?" -->
+
+## Hypothesis
+
+<!-- What do you expect to find, and why? This forces upfront thinking and
+     makes the conclusion more meaningful. -->
+
+## Context
+
+<!-- Why is this investigation needed right now? What design, plan, or
+     error triggered it? Link to the parent document(s). -->
+
+**Triggered by:** <!-- RFC-XXXX / DESIGN-XXXX / PLAN-XXXX / issue #XXX -->
+
+## Approach
+
+<!-- How will you test the hypothesis? List the specific steps, experiments,
+     or code paths you will exercise. Keep it concrete enough that someone
+     else could replicate the investigation. -->
+
+1.
+2.
+3.
+
+## Environment
+
+<!-- Versions, configuration, or setup details relevant to reproducibility.
+     Delete this section if not applicable. -->
+
+| Component | Version / Value |
+|-----------|----------------|
+|           |                |
+
+## Findings
+
+<!-- What did you actually observe? Include command output, logs, benchmark
+     numbers, or code snippets as evidence. Fill this in as you go. -->
+
+### Observation 1
+
+### Observation 2
+
+## Conclusion
+
+<!-- Answer the original question directly. State clearly what was found:
+     confirmed / refuted / inconclusive, and why. -->
+
+**Answer:** <!-- Yes / No / Inconclusive -->
+
+## Recommendation
+
+<!-- What should happen next based on this conclusion? Update the parent
+     doc, unblock the design decision, open a follow-up investigation, etc. -->
+
+## References
+
+<!-- Links to parent docs, related investigations, issues, external sources -->


### PR DESCRIPTION
Add a new INV (Investigation) document type for tracking time-boxed research
spikes and validation experiments.

## What

Investigations answer a specific question before committing to a design or
implementation — e.g. validating a library meets a requirement, reproducing a
weird error, or confirming a performance assumption. Any other doc type (RFC,
DESIGN, PLAN, IMPL) can reference an investigation by ID to show how an open
question was resolved before work began.

**New files:**
- `internal/template/templates/investigation.md` — document template
- `internal/template/templates/index_investigation.md` — README index header

**Template structure:** Question → Hypothesis → Context (with `Triggered by:` link
field) → Approach (numbered steps) → Environment table → Findings → Conclusion
(explicit `Answer: Yes / No / Inconclusive`) → Recommendation → References

**Config:** Added `investigation` to `DefaultConfig()` and `ValidTypes()` with
prefix `INV`, dir `docs/investigation/`, and statuses
`Open → In Progress → Concluded / Inconclusive / Abandoned`.

**Also:** Updated README and DEVELOPMENT docs to document the new type, updated
config tests for the new `ValidTypes()` length (4 → 5), regenerated golden
fixtures.

## Why

Designs and implementation plans frequently block on open questions that need
real work to validate — a prototype, a benchmark, a bug reproduction. Without
a structured place to track that work the results end up in Slack threads,
commit messages, or nowhere at all. Linking an investigation by ID gives
decision records a permanent, searchable audit trail.

Co-Authored-By: Claude <noreply@anthropic.com>