### PR TITLE
fix(config): wire plan type into config and fix docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -191,7 +191,7 @@ Add the new type to `DefaultConfig()`:
 
 ```go
 func ValidTypes() []string {
-    return []string{"rfc", "adr", "design", "impl", "investigation"}
+    return []string{"rfc", "adr", "design", "impl", "plan", "investigation"}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ README index tables up to date.
 
 ## Features
 
-- **Four built-in document types:** RFC, ADR, DESIGN, IMPL
+- **Six built-in document types:** RFC, ADR, DESIGN, IMPL, PLAN, INV
 - **Auto-incremented IDs:** documents are numbered sequentially within their type directory
 - **YAML frontmatter:** every document carries structured metadata (id, title, status, author, created)
 - **Auto-generated index tables:** README files in each type directory are updated automatically after each `create`
@@ -166,6 +166,17 @@ docs/impl/
 └── 0001-telemetry-pipeline-implementation.md
 ```
 
+### PLAN — Plan
+
+Mid-level planning documents that sit between an RFC (what and why) and an IMPL
+(step-by-step execution). Use a plan to work out the approach and component
+breakdown before writing detailed tasks.
+
+```
+docs/plan/
+└── 0001-telemetry-pipeline-approach.md
+```
+
 ### INV — Investigation
 
 Time-boxed research spikes and validation experiments. Use to answer a specific
@@ -243,6 +254,16 @@ types:
       - In Progress
       - Completed
       - Paused
+      - Cancelled
+  plan:
+    enabled: true
+    dir: plan
+    id_prefix: PLAN
+    id_width: 4
+    statuses:
+      - Draft
+      - In Progress
+      - Completed
       - Cancelled
   investigation:
     enabled: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,14 @@ func DefaultConfig() Config {
 				Statuses:    []string{"Draft", "In Progress", "Completed", "Paused", "Cancelled"},
 				StatusField: "status",
 			},
+			"plan": {
+				Enabled:     true,
+				Dir:         "plan",
+				IDPrefix:    "PLAN",
+				IDWidth:     4,
+				Statuses:    []string{"Draft", "In Progress", "Completed", "Cancelled"},
+				StatusField: "status",
+			},
 			"investigation": {
 				Enabled:     true,
 				Dir:         "investigation",
@@ -142,7 +150,7 @@ func (c *Config) TypeDir(docType string) string {
 
 // ValidTypes returns the list of built-in document type names.
 func ValidTypes() []string {
-	return []string{"rfc", "adr", "design", "impl", "investigation"}
+	return []string{"rfc", "adr", "design", "impl", "plan", "investigation"}
 }
 
 // Validate checks the configuration for common errors and returns a list of

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,7 +43,7 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestValidTypes(t *testing.T) {
 	types := ValidTypes()
-	want := []string{"rfc", "adr", "design", "impl", "investigation"}
+	want := []string{"rfc", "adr", "design", "impl", "plan", "investigation"}
 	if len(types) != len(want) {
 		t.Fatalf("ValidTypes() has %d elements, want %d", len(types), len(want))
 	}
@@ -100,8 +100,8 @@ func TestLoad_NoConfigFiles(t *testing.T) {
 	if cfg.DocsDir != "docs" {
 		t.Errorf("DocsDir = %q, want %q", cfg.DocsDir, "docs")
 	}
-	if len(cfg.Types) != 5 {
-		t.Errorf("expected 5 types, got %d", len(cfg.Types))
+	if len(cfg.Types) != 6 {
+		t.Errorf("expected 6 types, got %d", len(cfg.Types))
 	}
 }
 
@@ -141,8 +141,8 @@ author:
 		t.Error("Author.FromGit should be false")
 	}
 	// Types should still have defaults.
-	if len(cfg.Types) != 5 {
-		t.Errorf("expected 5 types, got %d", len(cfg.Types))
+	if len(cfg.Types) != 6 {
+		t.Errorf("expected 6 types, got %d", len(cfg.Types))
 	}
 }
 


### PR DESCRIPTION
The PLAN document type was added as a template in PR #6 but was never
registered in `DefaultConfig()` or `ValidTypes()`. This meant `docz create plan`
would fail with an unknown type error and `docz init` would not create the
`docs/plan/` directory.

## What

- Add `plan` to `DefaultConfig()` with prefix `PLAN`, dir `docs/plan/`, and
  statuses `Draft → In Progress → Completed / Cancelled`
- Add `plan` to `ValidTypes()`
- Update README: add missing `### PLAN — Plan` section under Document Types,
  update feature count from "Four" to "Six", add `plan` to the config YAML example
- Update DEVELOPMENT.md to show the correct full `ValidTypes()` list
- Update config tests to expect 6 types

## Why

Without the config registration the plan type existed only as an inert
template file — none of the CLI commands recognised it. This brings it to
parity with the other five types.

Fixes: plan type unusable via CLI (`docz create plan` / `docz init`)

Co-Authored-By: Claude <noreply@anthropic.com>