### PR TITLE
feat(cmd): add type aliases and fix help text for all commands

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -24,13 +24,17 @@ var createCmd = &cobra.Command{
 	Short: "Create a new document from a template",
 	Long: `Create a new document of the specified type with an auto-incremented ID.
 
-Types: rfc, adr, design, impl
+` + config.TypesHelp() + `
 
 Examples:
   docz create rfc "API Rate Limiting Strategy"
   docz create adr "Use PostgreSQL for Primary Storage"
   docz create design "User Authentication Flow"
-  docz create impl "Migrate to gRPC"`,
+  docz create impl "Migrate to gRPC"
+  docz create implementation "Migrate to gRPC"
+  docz create plan "Telemetry Pipeline Approach"
+  docz create investigation "Can pgvector Handle Concurrent Writes"
+  docz create inv "Can pgvector Handle Concurrent Writes"`,
 	Args: cobra.ExactArgs(2),
 	RunE: runCreate,
 }
@@ -43,7 +47,7 @@ func init() {
 }
 
 func runCreate(_ *cobra.Command, args []string) error {
-	docType := strings.ToLower(args[0])
+	docType := config.ResolveTypeAlias(strings.ToLower(args[0]))
 	title := args[1]
 
 	tc, ok := appCfg.Types[docType]

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -37,7 +37,7 @@ var listCmd = &cobra.Command{
 	Short: "List documents, optionally filtered by type",
 	Long: `List all documents across all types, or filter by a specific type.
 
-Types: rfc, adr, design, impl`,
+` + config.TypesHelp(),
 	Args: cobra.MaximumNArgs(1),
 	RunE: runList,
 }
@@ -51,7 +51,7 @@ func init() {
 func runList(_ *cobra.Command, args []string) error {
 	types := config.ValidTypes()
 	if len(args) > 0 {
-		typeName := strings.ToLower(args[0])
+		typeName := config.ResolveTypeAlias(strings.ToLower(args[0]))
 		if _, ok := appCfg.Types[typeName]; !ok {
 			return fmt.Errorf("unknown document type %q (valid types: %s)",
 				typeName, strings.Join(config.ValidTypes(), ", "))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,15 +36,11 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "docz",
 	Short: "A CLI tool for managing standardized repository documentation",
-	Long: `docz generates and manages standardized documentation files (RFC, ADR,
-DESIGN, IMPL) from templates. It creates documents with auto-incremented IDs,
-YAML frontmatter, and auto-generated index pages.
+	Long: `docz generates and manages standardized documentation files from templates.
+It creates documents with auto-incremented IDs, YAML frontmatter, and
+auto-generated index pages.
 
-Document types:
-  rfc      Request for Comments — high-level proposals
-  adr      Architecture Decision Records — technical decisions
-  design   Design documents — detailed feature designs
-  impl     Implementation plans — concrete tasks and milestones`,
+` + config.TypesHelp(),
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -68,7 +68,7 @@ func init() {
 }
 
 func runTemplateShow(_ *cobra.Command, args []string) error {
-	docType := strings.ToLower(args[0])
+	docType := config.ResolveTypeAlias(strings.ToLower(args[0]))
 	if err := validateType(docType); err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func runTemplateShow(_ *cobra.Command, args []string) error {
 }
 
 func runTemplateExport(_ *cobra.Command, args []string) error {
-	docType := strings.ToLower(args[0])
+	docType := config.ResolveTypeAlias(strings.ToLower(args[0]))
 	if err := validateType(docType); err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func runTemplateExport(_ *cobra.Command, args []string) error {
 }
 
 func runTemplateOverride(_ *cobra.Command, args []string) error {
-	docType := strings.ToLower(args[0])
+	docType := config.ResolveTypeAlias(strings.ToLower(args[0]))
 	if err := validateType(docType); err != nil {
 		return err
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -20,7 +20,7 @@ var updateCmd = &cobra.Command{
 	Long: `Regenerate the auto-generated table in the README.md for the specified
 document type directory. If no type is given, all types are updated.
 
-Types: rfc, adr, design, impl`,
+` + config.TypesHelp(),
 	Args: cobra.MaximumNArgs(1),
 	RunE: runUpdate,
 }
@@ -33,7 +33,7 @@ func init() {
 func runUpdate(_ *cobra.Command, args []string) error {
 	types := config.ValidTypes()
 	if len(args) > 0 {
-		typeName := strings.ToLower(args[0])
+		typeName := config.ResolveTypeAlias(strings.ToLower(args[0]))
 		if _, ok := appCfg.Types[typeName]; !ok {
 			return fmt.Errorf("unknown document type %q (valid types: %s)",
 				typeName, strings.Join(config.ValidTypes(), ", "))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,32 @@ func ValidTypes() []string {
 	return []string{"rfc", "adr", "design", "impl", "plan", "investigation"}
 }
 
+// typeAliases maps short or alternate names to their canonical type name.
+var typeAliases = map[string]string{
+	"implementation": "impl",
+	"inv":            "investigation",
+}
+
+// ResolveTypeAlias returns the canonical type name for the given input.
+// If the input is already a canonical name or has no alias, it is returned as-is.
+func ResolveTypeAlias(name string) string {
+	if canonical, ok := typeAliases[name]; ok {
+		return canonical
+	}
+	return name
+}
+
+// TypesHelp returns a formatted help string listing all valid types with aliases.
+func TypesHelp() string {
+	return `Document types:
+  rfc              Request for Comments — high-level proposals
+  adr              Architecture Decision Records — technical decisions
+  design           Design documents — detailed feature designs
+  impl             Implementation plans (alias: implementation)
+  plan             Planning documents — goal, approach, components
+  investigation    Research spikes — validate theories and errors (alias: inv)`
+}
+
 // Validate checks the configuration for common errors and returns a list of
 // warnings and the first error found (if any).
 func (c *Config) Validate() (warnings []string, err error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -162,6 +163,45 @@ func TestLoad_ExplicitConfigFile(t *testing.T) {
 
 	if cfg.DocsDir != "custom-docs" {
 		t.Errorf("DocsDir = %q, want %q", cfg.DocsDir, "custom-docs")
+	}
+}
+
+func TestResolveTypeAlias(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"impl", "impl"},
+		{"implementation", "impl"},
+		{"investigation", "investigation"},
+		{"inv", "investigation"},
+		{"rfc", "rfc"},
+		{"adr", "adr"},
+		{"design", "design"},
+		{"plan", "plan"},
+		{"unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ResolveTypeAlias(tt.input)
+			if got != tt.want {
+				t.Errorf("ResolveTypeAlias(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTypesHelp(t *testing.T) {
+	help := TypesHelp()
+	for _, typeName := range []string{"rfc", "adr", "design", "impl", "plan", "investigation"} {
+		if !strings.Contains(help, typeName) {
+			t.Errorf("TypesHelp() missing type %q", typeName)
+		}
+	}
+	for _, alias := range []string{"implementation", "inv"} {
+		if !strings.Contains(help, alias) {
+			t.Errorf("TypesHelp() missing alias %q", alias)
+		}
 	}
 }
 


### PR DESCRIPTION
Add shorthand aliases for longer type names and fix outdated help text
across all commands.

## Type Aliases

| Input | Resolves to |
|-------|-------------|
| `implementation` | `impl` |
| `inv` | `investigation` |

Works everywhere a type argument is accepted: `create`, `list`, `update`,
`template show`, `template export`, `template override`.

```bash
docz create implementation "Migrate to gRPC"   # same as: docz create impl ...
docz create inv "Can pgvector Handle Writes"    # same as: docz create investigation ...
docz list inv                                    # same as: docz list investigation
```

## Help Text

All commands previously hardcoded `Types: rfc, adr, design, impl` which
was missing `plan` and `investigation`. Replaced with a shared
`config.TypesHelp()` function that lists all six types with their
descriptions and aliases:

```
Document types:
  rfc              Request for Comments — high-level proposals
  adr              Architecture Decision Records — technical decisions
  design           Design documents — detailed feature designs
  impl             Implementation plans (alias: implementation)
  plan             Planning documents — goal, approach, components
  investigation    Research spikes — validate theories and errors (alias: inv)
```

## Tests

Added `TestResolveTypeAlias` (table-driven, covers all types + aliases +
unknown input) and `TestTypesHelp` (verifies all types and aliases appear
in the help string).

Co-Authored-By: Claude <noreply@anthropic.com>