### PR TITLE
fix: goreleaser ldflags and add mkdocs optional fields

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,9 @@ builds:
       - arm64
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/donaldgifford/docz/cmd.Version={{ .Version }}
+      - -X github.com/donaldgifford/docz/cmd.Commit={{ .ShortCommit }}
 
 archives:
   - id: default
@@ -72,7 +75,7 @@ release:
     # Download the appropriate binary for your system
     # Extract and move to your PATH
     tar -xzf docz_*.tar.gz
-    mv forge ~/.local/bin/
+    mv docz ~/.local/bin/
     ```
 
   footer: |

--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ wiki:
   mkdocs_path: mkdocs.yml
   plugins:                   # MkDocs plugins for wiki init
     - techdocs-core
+  markdown_extensions:       # MkDocs markdown extensions
+    - admonition
+    - tables
   exclude:
     - templates
     - examples
@@ -315,6 +318,10 @@ wiki:
     impl: "Implementation Plans"
     plan: "Plans"
     investigation: "Investigations"
+  # docs_dir: docs           # override MkDocs docs_dir
+  # repo_url: https://github.com/org/repo
+  # site_url: https://example.com/docs
+  # theme: readthedocs
 
 toc:
   enabled: true            # generate ToC during docz update
@@ -454,12 +461,24 @@ wiki:
   mkdocs_path: mkdocs.yml    # path to mkdocs.yml
   plugins:                   # MkDocs plugins written by wiki init
     - techdocs-core
+  markdown_extensions:       # MkDocs markdown extensions
+    - admonition
+    - tables
   exclude:                   # directories excluded from nav
     - templates
     - examples
   nav_titles:                # override directory display names
     rfc: "Request for Comments"
+  docs_dir: docs             # MkDocs docs_dir
+  repo_url: https://github.com/org/repo  # repository URL
+  site_url: https://example.com/docs     # published site URL
+  theme: readthedocs         # MkDocs theme
 ```
+
+All optional fields (`plugins`, `markdown_extensions`, `docs_dir`, `repo_url`,
+`site_url`, `theme`) are only written to `mkdocs.yml` during `wiki init` when
+set in the config. `wiki update` only modifies the `nav` section — manual edits
+to other fields are preserved.
 
 ### Homepage Template
 

--- a/cmd/wiki.go
+++ b/cmd/wiki.go
@@ -249,10 +249,33 @@ func writeMkDocsYAML(path, siteName, siteDesc string) error {
 	fmt.Fprintf(&b, "site_name: %s\n", siteName)
 	fmt.Fprintf(&b, "site_description: %s\n", siteDesc)
 
+	if appCfg.Wiki.DocsDir != "" {
+		fmt.Fprintf(&b, "docs_dir: %s\n", appCfg.Wiki.DocsDir)
+	}
+
+	if appCfg.Wiki.RepoURL != "" {
+		fmt.Fprintf(&b, "repo_url: %s\n", appCfg.Wiki.RepoURL)
+	}
+
+	if appCfg.Wiki.SiteURL != "" {
+		fmt.Fprintf(&b, "site_url: %s\n", appCfg.Wiki.SiteURL)
+	}
+
+	if appCfg.Wiki.Theme != "" {
+		fmt.Fprintf(&b, "theme: %s\n", appCfg.Wiki.Theme)
+	}
+
 	if len(appCfg.Wiki.Plugins) > 0 {
 		b.WriteString("\nplugins:\n")
 		for _, plugin := range appCfg.Wiki.Plugins {
 			fmt.Fprintf(&b, "    - %s\n", plugin)
+		}
+	}
+
+	if len(appCfg.Wiki.MarkdownExtensions) > 0 {
+		b.WriteString("\nmarkdown_extensions:\n")
+		for _, ext := range appCfg.Wiki.MarkdownExtensions {
+			fmt.Fprintf(&b, "    - %s\n", ext)
 		}
 	}
 

--- a/cmd/wiki_test.go
+++ b/cmd/wiki_test.go
@@ -532,6 +532,107 @@ func TestWikiInit_MultiplePlugins(t *testing.T) {
 	}
 }
 
+func TestWikiInit_MarkdownExtensions(t *testing.T) {
+	_ = setupWikiTestDir(t)
+	appCfg.Wiki.MarkdownExtensions = []string{"admonition", "tables", "pymdownx.tasklist"}
+
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runWikiInit(nil, nil)
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runWikiInit() error: %v", err)
+	}
+
+	data, err := os.ReadFile("mkdocs.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "markdown_extensions:") {
+		t.Error("mkdocs.yml should contain markdown_extensions section")
+	}
+	for _, ext := range []string{"admonition", "tables", "pymdownx.tasklist"} {
+		if !strings.Contains(content, "- "+ext) {
+			t.Errorf("mkdocs.yml should contain extension %q", ext)
+		}
+	}
+}
+
+func TestWikiInit_AllOptionalFields(t *testing.T) {
+	_ = setupWikiTestDir(t)
+	appCfg.Wiki.DocsDir = "documentation"
+	appCfg.Wiki.RepoURL = "https://github.com/example/repo"
+	appCfg.Wiki.SiteURL = "https://example.com/docs"
+	appCfg.Wiki.Theme = "readthedocs"
+
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runWikiInit(nil, nil)
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runWikiInit() error: %v", err)
+	}
+
+	data, err := os.ReadFile("mkdocs.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		"docs_dir: documentation",
+		"repo_url: https://github.com/example/repo",
+		"site_url: https://example.com/docs",
+		"theme: readthedocs",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("mkdocs.yml should contain %q", want)
+		}
+	}
+}
+
+func TestWikiInit_OmitsEmptyOptionalFields(t *testing.T) {
+	_ = setupWikiTestDir(t)
+	// All optional fields are zero values by default.
+
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runWikiInit(nil, nil)
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runWikiInit() error: %v", err)
+	}
+
+	data, err := os.ReadFile("mkdocs.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(data)
+	for _, absent := range []string{"docs_dir:", "repo_url:", "site_url:", "theme:", "markdown_extensions:"} {
+		if strings.Contains(content, absent) {
+			t.Errorf("mkdocs.yml should not contain %q when not configured", absent)
+		}
+	}
+}
+
 func TestWikiInit_IndexTemplate(t *testing.T) {
 	_ = setupWikiTestDir(t)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,11 +34,16 @@ type AuthorConfig struct {
 
 // WikiConfig holds configuration for the wiki/MkDocs integration.
 type WikiConfig struct {
-	AutoUpdate bool              `mapstructure:"auto_update" yaml:"auto_update"`
-	MkDocsPath string            `mapstructure:"mkdocs_path" yaml:"mkdocs_path"`
-	Plugins    []string          `mapstructure:"plugins"     yaml:"plugins"`
-	Exclude    []string          `mapstructure:"exclude"     yaml:"exclude"`
-	NavTitles  map[string]string `mapstructure:"nav_titles"  yaml:"nav_titles"`
+	AutoUpdate         bool              `mapstructure:"auto_update"         yaml:"auto_update"`
+	MkDocsPath         string            `mapstructure:"mkdocs_path"         yaml:"mkdocs_path"`
+	Plugins            []string          `mapstructure:"plugins"             yaml:"plugins,omitempty"`
+	MarkdownExtensions []string          `mapstructure:"markdown_extensions" yaml:"markdown_extensions,omitempty"`
+	Exclude            []string          `mapstructure:"exclude"             yaml:"exclude"`
+	NavTitles          map[string]string `mapstructure:"nav_titles"          yaml:"nav_titles"`
+	DocsDir            string            `mapstructure:"docs_dir"            yaml:"docs_dir,omitempty"`
+	RepoURL            string            `mapstructure:"repo_url"            yaml:"repo_url,omitempty"`
+	SiteURL            string            `mapstructure:"site_url"            yaml:"site_url,omitempty"`
+	Theme              string            `mapstructure:"theme"               yaml:"theme,omitempty"`
 }
 
 // ToCConfig holds configuration for table of contents generation.
@@ -103,11 +108,17 @@ func DefaultConfig() Config {
 				StatusField: "status",
 			},
 			"investigation": {
-				Enabled:     true,
-				Dir:         "investigation",
-				IDPrefix:    "INV",
-				IDWidth:     4,
-				Statuses:    []string{"Open", "In Progress", "Concluded", "Inconclusive", "Abandoned"},
+				Enabled:  true,
+				Dir:      "investigation",
+				IDPrefix: "INV",
+				IDWidth:  4,
+				Statuses: []string{
+					"Open",
+					"In Progress",
+					"Concluded",
+					"Inconclusive",
+					"Abandoned",
+				},
 				StatusField: "status",
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -268,6 +268,54 @@ func TestLoad_ToCConfig(t *testing.T) {
 	}
 }
 
+func TestLoad_WikiMarkdownExtensions(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "custom.yaml")
+	configContent := `wiki:
+  markdown_extensions:
+    - admonition
+    - tables
+    - pymdownx.tasklist
+  docs_dir: documentation
+  repo_url: https://github.com/example/repo
+  site_url: https://example.com/docs
+  theme: readthedocs
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	wantExts := []string{"admonition", "tables", "pymdownx.tasklist"}
+	if len(cfg.Wiki.MarkdownExtensions) != len(wantExts) {
+		t.Fatalf(
+			"Wiki.MarkdownExtensions has %d elements, want %d",
+			len(cfg.Wiki.MarkdownExtensions), len(wantExts),
+		)
+	}
+	for i, got := range cfg.Wiki.MarkdownExtensions {
+		if got != wantExts[i] {
+			t.Errorf("Wiki.MarkdownExtensions[%d] = %q, want %q", i, got, wantExts[i])
+		}
+	}
+	if cfg.Wiki.DocsDir != "documentation" {
+		t.Errorf("Wiki.DocsDir = %q, want %q", cfg.Wiki.DocsDir, "documentation")
+	}
+	if cfg.Wiki.RepoURL != "https://github.com/example/repo" {
+		t.Errorf("Wiki.RepoURL = %q, want %q", cfg.Wiki.RepoURL, "https://github.com/example/repo")
+	}
+	if cfg.Wiki.SiteURL != "https://example.com/docs" {
+		t.Errorf("Wiki.SiteURL = %q, want %q", cfg.Wiki.SiteURL, "https://example.com/docs")
+	}
+	if cfg.Wiki.Theme != "readthedocs" {
+		t.Errorf("Wiki.Theme = %q, want %q", cfg.Wiki.Theme, "readthedocs")
+	}
+}
+
 func TestLoad_WikiPlugins(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "custom.yaml")


### PR DESCRIPTION
## Summary

- **Fix goreleaser ldflags**: Released binaries were showing "dev (commit: none)" because `.goreleaser.yml` was missing `-X` flags for Version and Commit. Also fixes `mv forge` → `mv docz` typo in install instructions.
- **Add `markdown_extensions` to WikiConfig**: Configurable list of MkDocs markdown extensions (e.g. `admonition`, `tables`, `pymdownx.tasklist`). Written to `mkdocs.yml` by `wiki init` when set in `.docz.yaml`.
- **Add `docs_dir`, `repo_url`, `site_url`, `theme`**: Optional MkDocs fields configurable via `.docz.yaml`. Only written to `mkdocs.yml` when set — omitted when empty.
- All optional fields are only written during `wiki init`. `wiki update` only touches `nav`, so manual edits to these fields are preserved.

## Test plan

- [x] `make ci` passes (lint + test + build + license-check)
- [x] `TestLoad_WikiMarkdownExtensions` — config round-trip for all new fields
- [x] `TestWikiInit_MarkdownExtensions` — extensions written to mkdocs.yml
- [x] `TestWikiInit_AllOptionalFields` — docs_dir, repo_url, site_url, theme in mkdocs.yml
- [x] `TestWikiInit_OmitsEmptyOptionalFields` — empty fields not written

🤖 Generated with [Claude Code](https://claude.com/claude-code)