### PR TITLE
docs(impl): mark IMPL-0008 Completed after PRs #44 and #45 merged

### DIFF
--- a/docs/impl/0008-move-stranded-business-logic-into-internal-packages.md
+++ b/docs/impl/0008-move-stranded-business-logic-into-internal-packages.md
@@ -1,7 +1,7 @@
 ---
 id: IMPL-0008
 title: "Move Stranded Business Logic Into Internal Packages"
-status: Draft
+status: Completed
 author: Donald Gifford
 created: 2026-05-15
 ---
@@ -9,7 +9,7 @@ created: 2026-05-15
 
 # IMPL 0008: Move Stranded Business Logic Into Internal Packages
 
-**Status:** Draft
+**Status:** Completed (2026-05-27)
 **Author:** Donald Gifford
 **Date:** 2026-05-15
 
@@ -386,19 +386,19 @@ Drop the stutter and fix the initialism casing.
 - [x] Verify golden files: `testdata/golden/wiki/mkdocs_full.yml` added
       (new); all existing goldens unchanged (`go test ./... -update`
       shows no diff for adr/design/impl/rfc/toc/wiki/nav)
-- [x] Open PR A with `dont-release` label (Phases 1–3) — #44
-- [ ] After PR A merges: rebase, open PR B (Phases 4–10) with
-      `dont-release` label — branch `feat/impl-0008-pr-b` pushed and
-      ready (waiting on PR A merge per Decisions §6)
+- [x] Open PR A with `dont-release` label (Phases 1–3) — #44 (merged
+      2026-05-27)
+- [x] After PR A merges: rebase, open PR B (Phases 4–10) with
+      `dont-release` label — #45 (merged 2026-05-27)
 - [x] Update INV-0002 status — Wave 4 section now lists F11/F13/F17–F26
       against the two PRs
 
 #### Success Criteria
 
-- Two PRs merged with green CI
-- Manual smoke test passes
-- The `cmd/` package contains no business logic — only flag parsing,
-  config wiring, and calls into `internal/`
+- [x] Two PRs merged with green CI — PR #44 and PR #45
+- [x] Manual smoke test passes
+- [x] The `cmd/` package contains no business logic — only flag parsing,
+      config wiring, and calls into `internal/`
 
 ---
 
@@ -420,13 +420,15 @@ Drop the stutter and fix the initialism casing.
 
 ## Testing Plan
 
-- [ ] Each moved function gets unit tests in its new location (most will
+- [x] Each moved function gets unit tests in its new location (most will
       be copied + adapted from existing tests)
-- [ ] Back-compat test for `.docz.yaml` parsing with `toc:` key
-- [ ] Smoke test: run docz against the docz repo, verify all generated
+- [x] Back-compat test for `.docz.yaml` parsing with `toc:` key —
+      `TestLoad_TOCConfig`
+- [x] Smoke test: run docz against the docz repo, verify all generated
       files identical
-- [ ] Golden file regen happens exactly once (renames + reorganization
-      shouldn't change output)
+- [x] Golden file regen happens exactly once (renames + reorganization
+      shouldn't change output) — `testdata/golden/wiki/mkdocs_full.yml`
+      added; all others unchanged
 
 ## Decisions
 

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -39,6 +39,6 @@ docz create impl "Your Implementation Title"
 | IMPL-0005 | Mechanical Style and Idiom Cleanup | Completed | 2026-05-15 | Donald Gifford | [0005-mechanical-style-and-idiom-cleanup.md](0005-mechanical-style-and-idiom-cleanup.md) |
 | IMPL-0006 | Correctness and Duplication Cleanup | In Progress | 2026-05-15 | Donald Gifford | [0006-correctness-and-duplication-cleanup.md](0006-correctness-and-duplication-cleanup.md) |
 | IMPL-0007 | Eliminate Redundant File Reads and Heading Parses | In Progress | 2026-05-15 | Donald Gifford | [0007-eliminate-redundant-file-reads-and-heading-parses.md](0007-eliminate-redundant-file-reads-and-heading-parses.md) |
-| IMPL-0008 | Move Stranded Business Logic Into Internal Packages | Draft | 2026-05-15 | Donald Gifford | [0008-move-stranded-business-logic-into-internal-packages.md](0008-move-stranded-business-logic-into-internal-packages.md) |
+| IMPL-0008 | Move Stranded Business Logic Into Internal Packages | Completed | 2026-05-15 | Donald Gifford | [0008-move-stranded-business-logic-into-internal-packages.md](0008-move-stranded-business-logic-into-internal-packages.md) |
 | IMPL-0009 | Runner Pattern and DocType Registry Refactor | Draft | 2026-05-15 | Donald Gifford | [0009-runner-pattern-and-doctype-registry-refactor.md](0009-runner-pattern-and-doctype-registry-refactor.md) |
 <!-- END DOCZ AUTO-GENERATED -->


### PR DESCRIPTION
## Summary

Final Phase 11 (verify and ship) status update for IMPL-0008. Both stacked PRs (PR A #44 phases 1-3 and PR B #45 phases 4-10) merged to main on 2026-05-27 with green CI.

Changes:

- `docs/impl/0008-move-stranded-business-logic-into-internal-packages.md` — frontmatter `status: Draft` → `Completed`; Phase 11 + Testing Plan checkboxes ticked; PR B task no longer waiting on PR A.
- `docs/impl/README.md` — IMPL-0008 row regenerated by `docz update impl` to reflect the new status.

No code changes. Pure documentation status update.

## Test plan

- [x] `make lint` clean
- [x] `make test` all packages pass
- [x] `docz update impl` produces the IMPL README diff (status column only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)