### PR TITLE
docs: mark DESIGN-0006/IMPL-0012 implemented (post-merge of #56)

### DIFF
--- a/docs/design/0006-custom-document-type-support.md
+++ b/docs/design/0006-custom-document-type-support.md
@@ -1,7 +1,7 @@
 ---
 id: DESIGN-0006
 title: "Custom Document Type Support"
-status: Approved
+status: Implemented
 author: Donald Gifford
 created: 2026-06-17
 ---
@@ -9,7 +9,7 @@ created: 2026-06-17
 
 # DESIGN 0006: Custom Document Type Support
 
-**Status:** Approved
+**Status:** Implemented
 **Author:** Donald Gifford
 **Date:** 2026-06-17
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -37,5 +37,5 @@ docz create design "Your Design Title"
 | DESIGN-0003 | Table of Contents Generation | Draft | 2026-03-22 | Donald Gifford | [0003-table-of-contents-generation.md](0003-table-of-contents-generation.md) |
 | DESIGN-0004 | Runner Pattern and DocType Registry | Approved | 2026-05-27 | Donald Gifford | [0004-runner-pattern-and-doctype-registry.md](0004-runner-pattern-and-doctype-registry.md) |
 | DESIGN-0005 | Status Set CLI Primitive | Implemented | 2026-05-30 | Donald Gifford | [0005-status-set-cli-primitive.md](0005-status-set-cli-primitive.md) |
-| DESIGN-0006 | Custom Document Type Support | Approved | 2026-06-17 | Donald Gifford | [0006-custom-document-type-support.md](0006-custom-document-type-support.md) |
+| DESIGN-0006 | Custom Document Type Support | Implemented | 2026-06-17 | Donald Gifford | [0006-custom-document-type-support.md](0006-custom-document-type-support.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0012-custom-document-type-support.md
+++ b/docs/impl/0012-custom-document-type-support.md
@@ -1,7 +1,7 @@
 ---
 id: IMPL-0012
 title: "Custom Document Type Support"
-status: Draft
+status: Completed
 author: Donald Gifford
 created: 2026-06-18
 ---
@@ -9,7 +9,7 @@ created: 2026-06-18
 
 # IMPL 0012: Custom Document Type Support
 
-**Status:** Draft
+**Status:** Completed
 **Author:** Donald Gifford
 **Date:** 2026-06-18
 
@@ -364,9 +364,9 @@ resolution keys require.
       Features bullet + index-header override note; generated `.docz.yaml`
       `types:` comment block and commented example custom type; `docz create`
       `--help` note that custom types resolve by name / alias / `id_prefix`
-- [ ] Flip DESIGN-0006 frontmatter status `Approved` → `Implemented` after
+- [x] Flip DESIGN-0006 frontmatter status `Approved` → `Implemented` after
       merge to main *(post-merge)*
-- [ ] Flip this doc's frontmatter status `Draft` → `Completed` after merge
+- [x] Flip this doc's frontmatter status `Draft` → `Completed` after merge
       to main *(post-merge)*
 - [x] Open the PR with the `minor` release label (new user-facing feature,
       additive) — single PR per Decision 8

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -42,5 +42,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0008 | Move Stranded Business Logic Into Internal Packages | Completed | 2026-05-15 | Donald Gifford | [0008-move-stranded-business-logic-into-internal-packages.md](0008-move-stranded-business-logic-into-internal-packages.md) |
 | IMPL-0009 | Runner Pattern and DocType Registry Refactor | Completed | 2026-05-15 | Donald Gifford | [0009-runner-pattern-and-doctype-registry-refactor.md](0009-runner-pattern-and-doctype-registry-refactor.md) |
 | IMPL-0011 | Status Set CLI Primitive | Completed | 2026-06-01 | Donald Gifford | [0011-status-set-cli-primitive.md](0011-status-set-cli-primitive.md) |
-| IMPL-0012 | Custom Document Type Support | Draft | 2026-06-18 | Donald Gifford | [0012-custom-document-type-support.md](0012-custom-document-type-support.md) |
+| IMPL-0012 | Custom Document Type Support | Completed | 2026-06-18 | Donald Gifford | [0012-custom-document-type-support.md](0012-custom-document-type-support.md) |
 <!-- END DOCZ AUTO-GENERATED -->


### PR DESCRIPTION
Post-merge cleanup for #56 (custom document type support).

- DESIGN-0006 `Approved` → `Implemented`
- IMPL-0012 `Draft` → `Completed`
- Checks off the two `*(post-merge)*` tasks in IMPL-0012
- Refreshes the design/impl README index tables (status column)

Docs-only; no release (`dont-release`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)