### PR TITLE
docs: INV-0005 + DESIGN-0007/0008/0009 for docz-api and docz-site

### DIFF
--- a/docs/design/0007-docz-changes-to-support-docz-api-and-docz-site.md
+++ b/docs/design/0007-docz-changes-to-support-docz-api-and-docz-site.md
@@ -1,0 +1,738 @@
+---
+id: DESIGN-0007
+title: "docz changes to support docz-api and docz-site"
+status: Draft
+author: Donald Gifford
+created: 2026-06-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0007: docz changes to support docz-api and docz-site
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-23
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [What becomes public](#what-becomes-public)
+  - [Proposed package name and path](#proposed-package-name-and-path)
+  - [Move-wholesale vs. shim — recommendation](#move-wholesale-vs-shim--recommendation)
+  - [How existing packages relate afterward](#how-existing-packages-relate-afterward)
+  - [Key exported signatures (post-promotion)](#key-exported-signatures-post-promotion)
+  - [The semver obligation that promotion creates](#the-semver-obligation-that-promotion-creates)
+  - [How docz-api pins and consumes it](#how-docz-api-pins-and-consumes-it)
+  - [Optional: docz export --json (secondary)](#optional-docz-export---json-secondary)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+  - [Exported Go shapes (the contract)](#exported-go-shapes-the-contract)
+  - [Optional JSON manifest schema (only if docz export ships)](#optional-json-manifest-schema-only-if-docz-export-ships)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+  - [1. What is the public package name/path and shape?](#1-what-is-the-public-package-namepath-and-shape)
+  - [2. Move wholesale (update all imports) vs. leave permanent re-export shims?](#2-move-wholesale-update-all-imports-vs-leave-permanent-re-export-shims)
+  - [3. Add docz export --json now, or defer it?](#3-add-docz-export---json-now-or-defer-it)
+  - [4. Module/versioning strategy?](#4-moduleversioning-strategy)
+  - [5. How much surface to expose?](#5-how-much-surface-to-expose)
+  - [6. If docz export ships, what is the manifest schema shape?](#6-if-docz-export-ships-what-is-the-manifest-schema-shape)
+  - [7. Does docz-api vendor a docz checkout or always consume the library via go.mod?](#7-does-docz-api-vendor-a-docz-checkout-or-always-consume-the-library-via-gomod)
+  - [8. Where does the consumer import smoke test live?](#8-where-does-the-consumer-import-smoke-test-live)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+INV-0005 concluded that a cross-repo aggregation service (**docz-api**) and a
+viewer (**docz-site**) are feasible, and that the dominant simplification over a
+general system like rfc-api is that docz already standardizes location
+(`.docz.yaml`), structure (typed directories), and metadata (typed
+frontmatter). The investigation's Decision 7 (accepted) commits to one
+prerequisite *inside the docz CLI repo*: stop the API from re-implementing —
+and therefore drifting from — docz's own config and frontmatter parsing, by
+**promoting that parsing out of `internal/` into a reusable, importable public
+Go package** that both the CLI and docz-api consume.
+
+This design is the docz-side enabler and nothing more. It does not design the
+service or the viewer (those are DESIGN-0008 and DESIGN-0009). It specifies
+exactly which types and functions become public, the package name and path, the
+package boundary (what stays `internal/` vs. what is promoted), how the existing
+`internal/config` and `internal/document` packages relate to the new package
+afterward, the semver obligation that promotion creates, how docz-api pins and
+consumes the result, and — as a clearly secondary, optional item — whether a
+`docz export --json` whole-repo manifest is worth shipping now for non-Go
+consumers.
+
+The work is behavior-preserving for the CLI: no command output changes, no new
+required flags, no config-format change. It is a code-organization change plus a
+new public import surface and a tagged release.
+
+## Goals and Non-Goals
+
+### Goals
+
+- **One source of truth for "what docz docs exist in a tree."** docz-api imports
+  the same `Load` / `Validate` / type-resolution and `ScanDocuments` /
+  `LoadFrontmatter` code the CLI runs, so a custom type, an alias, or a
+  frontmatter quirk parses identically in both.
+- **Promote the parsing core to an importable public package.** Today the
+  relevant code lives under `internal/config` and `internal/document`, which Go
+  forbids any other module from importing. Move the consumable surface to a
+  `pkg/…` path that external modules can import.
+- **Keep the CLI behavior byte-for-byte identical.** All `cmd/` packages
+  continue to compile and produce the same output; golden files do not change.
+- **Establish a deliberate, minimal public API surface.** Promote what an
+  ingester actually needs (config load + validate + type resolution + document
+  scan + frontmatter parse) and keep CLI-only concerns (`SetStatus` byte
+  mutation, template rendering, index/ToC splicing, wiki nav) out of the public
+  surface unless there is a concrete consumer.
+- **Acknowledge the semver obligation that promotion creates** and pick a
+  module/versioning strategy docz-api can pin against.
+
+### Non-Goals
+
+- **Designing docz-api or docz-site.** Fetch strategy, Postgres schema, webhook
+  refresh, Meilisearch indexing, and the pluggable auth layer are all
+  out of scope here (DESIGN-0008 / DESIGN-0009).
+- **Changing the `.docz.yaml` format or any frontmatter contract.** The shapes
+  are promoted as-is; this is a visibility change, not a schema change.
+- **Building a server-side renderer.** Decision 3 of INV-0005 renders markdown
+  in docz-site (JS); docz exposes no rendering API here.
+- **Exposing the template / index / toc / wiki packages.** Those are CLI output
+  concerns the API does not need; they stay `internal/`.
+- **Auto-discovering types from the filesystem.** A type is still whatever
+  `.docz.yaml` declares (DESIGN-0006); the public package reads that config, it
+  does not invent types.
+
+## Background
+
+INV-0005 Observation 4 ("don't re-implement the parser") laid out three ways the
+API could obtain a repo's doc list: (1) a shared Go library, (2) a
+machine-readable `docz export --json`, or (3) shelling out to the binary.
+Decision 7 chose **option 1** — the shared library — because it makes docz-api a
+true peer of the CLI with zero drift risk, where shelling out couples deployment
+to a checkout + installed binary and a JSON export is a serialization the API
+must still trust to match the CLI.
+
+The thing standing in the way is purely Go's visibility rule. Everything the API
+wants is already written and tested; it just lives in import-blocked locations:
+
+- `internal/config` — `Config`, `TypeConfig`, `DocType`, `Status`,
+  `DocTypeDef`, `Load`, `Validate`, `DefaultConfig`, `EnabledTypes`,
+  `ValidateType`, `resolveType`, `DocTypeNames`, `AllDocTypes`,
+  `LookupDocType`, `ResolveTypeAlias`.
+- `internal/document` — `Frontmatter`, `DocEntry`, `ScanDocuments`,
+  `LoadFrontmatter`, `ParseFrontmatter`, `IsDoczFile`, `SetStatus` (and its
+  sentinels `ErrNoFrontmatter`, `ErrStatusFieldMissing`,
+  `ErrUnsupportedLineEndings`).
+
+An ingester reading a checked-out (or API-fetched) repo needs almost exactly the
+sequence the CLI already runs:
+
+```text
+Load(configFile, repoRoot) → Validate() → for each EnabledTypes():
+    ScanDocuments(cfg.TypeDir(name)) → []DocEntry{ Frontmatter, Filename, Content }
+```
+
+That maps one-to-one onto the registry row described in INV-0005 Observation 1
+(`id`, `title`, `status`, `author`, `created`, path) and onto the per-type
+metadata (`dir`, `id_prefix`, `id_width`, `statuses`, `plural_label`,
+`aliases`). The registry must be **type-agnostic** — driven entirely by the
+repo's config, never a hardcoded list of the six built-ins (INV-0005 Obs 1,
+DESIGN-0006). Promoting `Config` + `EnabledTypes` + `ScanDocuments` is precisely
+what makes that possible without a second parser.
+
+One subtlety worth stating up front: `document.Frontmatter.Status` is typed
+`config.Status` and the registry's `DocType` is typed `config.DocType` — so
+`document` already depends on `config`. Any promotion must keep those two
+packages on the same side of the public/internal line, or the typed fields break
+the import graph. This design keeps them together in one public module.
+
+## Detailed Design
+
+### What becomes public
+
+The promoted surface is the union of the two packages' export-worthy symbols,
+trimmed to what an external consumer (docz-api) actually needs. Concretely:
+
+**From `internal/config`:**
+
+| Symbol | Kind | Why an external consumer needs it |
+|---|---|---|
+| `Config` | struct | The parsed `.docz.yaml`; the manifest |
+| `TypeConfig` | struct | Per-type metadata (dir, id_prefix, statuses, …) |
+| `DocType`, `Status` | typed strings | Boundary types on frontmatter / type fields |
+| `DocTypeDef`, `AllDocTypes`, `LookupDocType`, `DocTypeNames` | registry | Enumerate/validate built-in types |
+| `Load(configFile, repoRoot string) (Config, error)` | func | Parse a repo's config |
+| `DefaultConfig() Config` | func | Defaults when no `.docz.yaml` present |
+| `(*Config).Validate() ([]string, error)` | method | Reject ambiguous/invalid config before ingest |
+| `(*Config).EnabledTypes() []string` | method | The type set to scan (incl. custom types) |
+| `(*Config).TypeDir(string) string` | method | Resolve `<docs_dir>/<dir>` to scan |
+| `(*Config).ValidateType(string) (string, error)` | method | Canonicalize a user/URL token to a type |
+| `ResolveTypeAlias`, `ErrUnknownType` | func / sentinel | Alias resolution + typed error branch |
+
+**From `internal/document`:**
+
+| Symbol | Kind | Why an external consumer needs it |
+|---|---|---|
+| `Frontmatter` | struct | The five typed metadata fields |
+| `DocEntry` | struct | `Frontmatter` + `Filename` + `Content` per doc |
+| `ScanDocuments(dir string) ([]DocEntry, error)` | func | Scan one type directory |
+| `LoadFrontmatter(path string) (Frontmatter, []byte, error)` | func | Parse one file (with fallback semantics) |
+| `ParseFrontmatter(content []byte) (Frontmatter, error)` | func | Parse already-fetched bytes (no disk read) |
+| `IsDoczFile(name string) bool` | func | Filter a Trees/Contents listing |
+| `ErrNoFrontmatter` | sentinel | `errors.Is` fallback branch |
+
+`ParseFrontmatter` deserves emphasis: docz-api fetches bytes over the GitHub
+Contents API (INV-0005 Decision 1) and never touches a local checkout, so a
+content-from-bytes entry point — not just the disk-reading `LoadFrontmatter` —
+is the one the service uses most. It already exists; promotion just exposes it.
+
+**What stays `internal/` (recommended):**
+
+- `SetStatus` and its CR/CRLF and status-field-missing sentinels — a byte-level
+  *mutator* the CLI's `status set` owns. The API ingests read-only (default
+  branch HEAD, Decision 4/5); it does not write back. Keep it internal until a
+  consumer appears (tracked as an open question).
+- `internal/template`, `internal/index`, `internal/toc`, `internal/wiki` —
+  output/rendering/splicing concerns docz-site replaces with a JS renderer
+  (Decision 3). No API need; keep internal.
+- `cmd/`, `cmd.Runner` — the CLI shell.
+
+### Proposed package name and path
+
+Recommended: preserve the existing two-package split under `pkg/` so the typed
+`Status`/`DocType` boundary and the existing test layout move wholesale with
+minimal churn, grouped under a `doczcore` namespace:
+
+```text
+github.com/donaldgifford/docz
+├── pkg/
+│   └── doczcore/
+│       ├── config/        # was internal/config (moved wholesale)
+│       │   ├── config.go
+│       │   ├── doctype.go
+│       │   └── constants.go
+│       └── document/      # was internal/document (moved wholesale)
+│           ├── document.go
+│           ├── scan.go
+│           └── status.go  # SetStatus stays here but is a candidate to keep
+│                          #   internal; see open question 5
+├── internal/
+│   ├── template/          # unchanged, now imports pkg/doczcore/config
+│   ├── index/
+│   ├── toc/
+│   └── wiki/
+└── cmd/                   # unchanged behavior, imports updated
+```
+
+`pkg/doczcore/config` and `pkg/doczcore/document` keep the package names
+`config` and `document`, so within the moved files almost nothing changes —
+only the *import paths* that reference them elsewhere do. The `doczcore` grouping
+namespaces the public surface and signals "this is the importable core,"
+distinct from the CLI-private `internal/` tree.
+
+(If a single flat package is preferred for a smaller surface, `pkg/doczcore`
+with both files merged is viable but forces a rename of every `config.` /
+`document.` qualifier across the moved code and the CLI — more churn for a
+cosmetic gain. The two-subpackage layout is recommended; see open question 1.)
+
+### Move-wholesale vs. shim — recommendation
+
+Two ways to relate `internal/` to the new `pkg/`:
+
+1. **Move wholesale + update all `cmd/` and `internal/` imports.** Physically
+   `git mv internal/config → pkg/doczcore/config` and
+   `internal/document → pkg/doczcore/document`, then update every import path in
+   `cmd/`, `internal/template`, `internal/index`, `internal/toc`,
+   `internal/wiki`, and the moved files' cross-references. No code logic
+   changes; only import strings and the package's on-disk location.
+2. **Move + leave thin re-export shims** at the old `internal/config` /
+   `internal/document` paths (`type Config = doczcore.Config`,
+   `var Load = doczcore.Load`, …) so existing CLI imports keep compiling
+   untouched.
+
+**Recommendation: option 1 (move wholesale, update imports).** Rationale:
+
+- The repo controls all of its own callers — `cmd/` and the four `internal/`
+  output packages — so updating imports is a mechanical, compiler-verified sweep
+  (`goimports` + build), not a risky refactor. The shim only buys value when
+  *external* callers you don't control would break, which is not the case for a
+  single repo's own internal imports.
+- A permanent shim leaves two import paths for the same type forever, inviting
+  confusion ("which `Config` is canonical?") and a slow rot where new code
+  imports the deprecated path. Decision 7's whole point is *one* source of
+  truth; two paths undercuts it.
+- Type aliases (`=`) make a shim *type-identical*, so it would work — but it is
+  unjustified indirection for in-repo callers. Drop it.
+
+The one acceptable use of a shim is **transitional**, inside a single PR, if the
+import sweep is too large to land atomically — re-export, migrate callers in
+follow-ups, delete the shim before release. Even then, the shim must not survive
+the release that introduces `pkg/doczcore`.
+
+### How existing packages relate afterward
+
+- `internal/template` keeps importing the config package, now at
+  `pkg/doczcore/config` (it already references `config.TemplatesDir` and friends).
+  One import line changes per file.
+- `internal/index`, `internal/toc`, `internal/wiki` already depend on
+  `document.DocEntry` / `config` types; their imports repoint to
+  `pkg/doczcore/...`. No logic change.
+- `cmd/` handlers (`runner.go` bundles `config.Config`; `create`, `update`,
+  `list`, `status`, `init`, `wiki` all reference both packages) repoint their
+  imports. `cmd.Runner.Cfg` is `config.Config` → now `doczcore/config.Config`,
+  same struct.
+- The `internal/document` → `internal/config` dependency becomes
+  `pkg/doczcore/document` → `pkg/doczcore/config`, preserved verbatim, so the
+  typed `Status` / `DocType` fields keep compiling.
+
+### Key exported signatures (post-promotion)
+
+These are the existing signatures, unchanged except for their import path:
+
+```go
+package config // github.com/donaldgifford/docz/pkg/doczcore/config
+
+type DocType string
+type Status  string
+
+type TypeConfig struct {
+    Enabled     bool
+    Dir         string
+    Template    string
+    IDPrefix    string
+    IDWidth     int
+    Statuses    []string
+    StatusField string
+    PluralLabel string
+    Aliases     []string
+}
+
+type Config struct {
+    DocsDir string
+    Types   map[string]TypeConfig
+    Index   IndexConfig
+    Author  AuthorConfig
+    Wiki    WikiConfig
+    TOC     TOCConfig
+}
+
+func Load(configFile, repoRoot string) (Config, error)
+func DefaultConfig() Config
+
+func (c *Config) Validate() ([]string, error)
+func (c *Config) EnabledTypes() []string
+func (c *Config) TypeDir(docType string) string
+func (c *Config) ValidateType(name string) (string, error)
+
+func DocTypeNames() []string
+func AllDocTypes() []DocTypeDef
+func LookupDocType(name string) (DocTypeDef, bool)
+func ResolveTypeAlias(name string) string
+
+var ErrUnknownType error
+```
+
+```go
+package document // github.com/donaldgifford/docz/pkg/doczcore/document
+
+type Frontmatter struct {
+    ID      string
+    Title   string
+    Status  config.Status
+    Author  string
+    Created string
+}
+
+type DocEntry struct {
+    Frontmatter
+    Filename string
+    Content  []byte
+}
+
+func ScanDocuments(dir string) ([]DocEntry, error)
+func LoadFrontmatter(path string) (Frontmatter, []byte, error)
+func ParseFrontmatter(content []byte) (Frontmatter, error)
+func IsDoczFile(name string) bool
+
+var ErrNoFrontmatter error
+```
+
+A docz-api ingester then becomes, in full:
+
+```go
+import (
+    "github.com/donaldgifford/docz/pkg/doczcore/config"
+    "github.com/donaldgifford/docz/pkg/doczcore/document"
+)
+
+func ingest(repoRoot string) ([]document.DocEntry, error) {
+    cfg, err := config.Load("", repoRoot) // reads <repoRoot>/.docz.yaml
+    if err != nil {
+        return nil, err
+    }
+    if _, err := cfg.Validate(); err != nil {
+        return nil, err
+    }
+    var all []document.DocEntry
+    for _, t := range cfg.EnabledTypes() { // incl. custom types
+        docs, err := document.ScanDocuments(cfg.TypeDir(t))
+        if err != nil {
+            return nil, err
+        }
+        all = append(all, docs...)
+    }
+    return all, nil
+}
+```
+
+When fetching over the Contents API (no checkout), the service substitutes its
+own directory walk and calls `document.ParseFrontmatter(bytes)` per fetched file
+instead of `ScanDocuments(dir)`, reusing `config.Config` + `IsDoczFile` to know
+*which* paths to fetch.
+
+### The semver obligation that promotion creates
+
+Moving a symbol from `internal/` to `pkg/` is a one-way commitment: once an
+external module imports `pkg/doczcore`, **its types and signatures become part
+of docz's public API and are governed by semver**. A field rename on
+`TypeConfig`, a signature change on `Load`, or a removal of `ScanDocuments` is
+then a breaking change requiring a major-version bump — not the free internal
+refactor it is today (compare DESIGN-0006, which freely reshaped
+`internal/index` signatures).
+
+This is the real cost of Decision 7 and the reason to keep the promoted surface
+**minimal**: every public symbol is a future compatibility constraint. Concrete
+implications:
+
+- The promoted structs (`Config`, `TypeConfig`, `Frontmatter`, `DocEntry`)
+  freeze their field names/tags as API. Adding fields is non-breaking; renaming
+  or removing is breaking.
+- `Load` / `Validate` / `ScanDocuments` / `LoadFrontmatter` /
+  `ParseFrontmatter` signatures freeze. Future needs should be met with new
+  functions or option structs, not signature changes.
+- The sentinel errors (`ErrUnknownType`, `ErrNoFrontmatter`) become a supported
+  `errors.Is` contract.
+- CLI-only churn (template/index/toc/wiki refactors like DESIGN-0006's) stays
+  free because those packages remain `internal/`.
+
+### How docz-api pins and consumes it
+
+docz-api adds an ordinary module dependency:
+
+```text
+// docz-api/go.mod
+require github.com/donaldgifford/docz vX.Y.Z
+```
+
+```go
+import "github.com/donaldgifford/docz/pkg/doczcore/config"
+import "github.com/donaldgifford/docz/pkg/doczcore/document"
+```
+
+The docz module is tagged (e.g. `vX.Y.0`, the minor release that introduces
+`pkg/doczcore`) and docz-api pins that tag in `go.mod` like any third-party
+dependency; Go's module proxy + `go.sum` give reproducible builds. Because the
+public surface is semver-governed, docz-api can rely on `go get -u` within a
+major version being non-breaking. No `replace` directive, no vendored checkout
+of docz's source is required (whether docz-api *additionally* vendors for
+hermetic builds is an open question, not a requirement).
+
+Note the module path. If docz is still pre-`v1` (`v0.x`), the
+"minor versions may break" caveat of `v0` applies and docz-api pins exact tags;
+once docz hits `v1`, the `/v2` import-path rule kicks in for future majors.
+Whether to cut a `v1.0.0` *because* this is now a public API, or keep iterating
+in `v0.x` with exact pins, is open question 4.
+
+### Optional: `docz export --json` (secondary)
+
+INV-0005 Observation 4 lists a `docz export --json` whole-repo manifest as
+option 2 — explicitly *not* the chosen primary. It is worth keeping on the table
+as a **convenience for non-Go consumers** (a script, a CI step, a future
+non-Go service) that cannot import a Go package, and as a debugging aid
+("what does docz think is in this tree?"). It is **not** how docz-api consumes
+docz — the library is. Treat it as secondary and gate it behind an open
+question (3).
+
+If shipped, it is a thin CLI command over the *same* promoted library — it must
+not grow a second parser — emitting the resolved config + every enabled type +
+every doc's frontmatter + path as one JSON document. Sketch in
+[Data Model](#data-model). Because it serializes the public structs, its JSON
+shape also becomes a compatibility surface (golden-tested), which is a second
+reason to defer it unless a concrete non-Go consumer materializes.
+
+## API / Interface Changes
+
+- **New public package path(s):** `github.com/donaldgifford/docz/pkg/doczcore/config`
+  and `…/pkg/doczcore/document`, containing the symbols listed in
+  [What becomes public](#what-becomes-public). These are *moved*, not new code.
+- **Removed import paths (internal):** `internal/config` and
+  `internal/document` cease to exist (no transitional shim survives release).
+  This is invisible outside the repo — `internal/` was never importable.
+- **No breaking CLI changes:** no command renamed, no flag added or removed
+  (excepting the optional `docz export`, below), no output format changed, no
+  `.docz.yaml` schema change. The CLI is a consumer of the moved package.
+- **Optional new CLI command (open question 3):** `docz export [--format=json]`,
+  read-only, emitting the whole-repo manifest to stdout (respecting the existing
+  `Runner.Out` seam). No effect on any existing command. If deferred, no CLI
+  change ships at all.
+- **New module-level public API surface** subject to semver, per
+  [the semver obligation](#the-semver-obligation-that-promotion-creates). This is
+  the only "breaking-in-the-future-is-now-expensive" consequence, and it is
+  intentional.
+
+## Data Model
+
+No persisted-data, frontmatter, README-marker, or `.docz.yaml` schema changes.
+The "data model" of this design is the *exported Go shapes* that become the
+contract, plus the optional JSON manifest if `docz export` ships.
+
+### Exported Go shapes (the contract)
+
+The promoted structs, frozen as public API (fields per the real definitions in
+`internal/config/config.go` and `internal/document/`):
+
+- `config.Config{ DocsDir, Types map[string]TypeConfig, Index, Author, Wiki,
+  TOC }`
+- `config.TypeConfig{ Enabled, Dir, Template, IDPrefix, IDWidth, Statuses,
+  StatusField, PluralLabel, Aliases }`
+- `config.DocType`, `config.Status` (typed strings)
+- `document.Frontmatter{ ID, Title, Status config.Status, Author, Created }`
+- `document.DocEntry{ Frontmatter, Filename, Content []byte }`
+
+`DocEntry.Content` carries the raw file bytes (`scan.go` populates it
+unconditionally) — exactly the `raw_md` the registry caches at ingest (INV-0005
+Decision 2). The API does not need a separate read.
+
+### Optional JSON manifest schema (only if `docz export` ships)
+
+A single object — resolved config, every enabled type, every doc:
+
+```json
+{
+  "schema_version": 1,
+  "docs_dir": "docs",
+  "types": [
+    {
+      "name": "rfc",
+      "dir": "rfc",
+      "id_prefix": "RFC",
+      "id_width": 4,
+      "plural_label": "RFCs",
+      "statuses": ["Draft", "Proposed", "Accepted", "Rejected", "Superseded"],
+      "aliases": [],
+      "enabled": true
+    }
+  ],
+  "documents": [
+    {
+      "type": "rfc",
+      "id": "RFC-0001",
+      "title": "Example",
+      "status": "Accepted",
+      "author": "Donald Gifford",
+      "created": "2026-01-01",
+      "path": "docs/rfc/0001-example.md"
+    }
+  ]
+}
+```
+
+`path` is repo-root-relative (`<docs_dir>/<dir>/<filename>`). `documents` is
+sorted by `(type, id)` for golden stability. `schema_version` is an explicit
+integer so a future field addition does not silently break a non-Go consumer.
+Raw markdown is intentionally omitted from the default export (it bloats the
+manifest and the Go library already exposes `DocEntry.Content`); a `--content`
+flag could include it if a consumer needs it (open question 6).
+
+## Testing Strategy
+
+- **Existing tests move with the code, unchanged.** `internal/config/*_test.go`
+  and `internal/document/*_test.go` (table-driven, `t.Parallel()`, golden
+  fixtures under `internal/document/testdata/golden/status/`) move to
+  `pkg/doczcore/config` and `pkg/doczcore/document`. The move is import-path-only;
+  assertions and golden bytes are unchanged, proving behavior is preserved.
+  Golden files are regenerated only to confirm *no diff* (`go test ./...
+  -update` must produce zero churn).
+- **CLI regression suite stays green.** `cmd/` tests (serial, `Runner` +
+  `bytes.Buffer`, `RepoRoot: t.TempDir()`) must pass untouched except for
+  import paths, proving the CLI is behavior-identical after the move.
+- **New consumer / import smoke test.** Add a tiny test module (a separate
+  `go.mod` under `test/consumer/` or an in-repo peer test that exercises the
+  package as an external caller would) that:
+  - imports `pkg/doczcore/config` and `pkg/doczcore/document` *by their public
+    paths*,
+  - writes a `.docz.yaml` + a couple of docs into a `t.TempDir()`,
+  - runs `Load → Validate → EnabledTypes → ScanDocuments` and asserts the
+    `DocEntry` set, including a **custom type** (to lock in the type-agnostic
+    contract from INV-0005 Obs 1), and
+  - calls `ParseFrontmatter` on raw bytes (the no-checkout path) and asserts
+    the parsed `Frontmatter`.
+  This is the test that would have caught a regression where promotion
+  accidentally narrowed visibility or broke the `document → config` typed-field
+  link.
+- **Golden stability for `docz export` (only if shipped).** A golden JSON
+  fixture for a fixed repo + `.docz.yaml`; regenerated with `-update`, never
+  hand-edited; asserts deterministic ordering (`documents` sorted by
+  `(type, id)`) so the manifest is diff-stable across runs.
+- **`make ci` unchanged** — lint (`golangci-lint` + `golines`),
+  license-check, build, and the full test suite gate the move.
+
+## Migration / Rollout Plan
+
+Behavior-preserving, single-repo, mechanical. Sequencing:
+
+1. **Move the packages.** `git mv internal/config → pkg/doczcore/config` and
+   `internal/document → pkg/doczcore/document`, preserving package names
+   (`config`, `document`) so only on-disk location and import paths change.
+2. **Update internal imports.** Repoint `cmd/` and `internal/template` /
+   `index` / `toc` / `wiki` to the new `pkg/doczcore/...` paths
+   (`goimports` + `go build ./...`). The `document → config` import repoints
+   too. This is compiler-verified — the build fails loudly until every path is
+   fixed.
+3. **Run the suite.** `make test` must be green with zero golden churn,
+   confirming behavior is identical. Add the consumer import smoke test.
+4. **Keep CLI behavior identical.** No command, flag, output, or config change
+   in this step. (`docz export` is a *separate, optional, later* increment — do
+   not bundle it into the move; see open question 3.)
+5. **Tag a minor release.** Cut `vX.Y.0` (or `v1.0.0` if the decision is to
+   declare the public API stable — open question 4) so docz-api has a concrete
+   tag to `require`. Note in release notes that `pkg/doczcore` is now a
+   supported, semver-governed public surface and that `internal/config` /
+   `internal/document` import paths are gone (invisible to anyone outside the
+   repo).
+6. **(Optional, deferred) ship `docz export --json`** as its own minor release
+   if/when a non-Go consumer needs it, built strictly on the promoted library.
+
+**Sequencing relative to building docz-api:** this design is a prerequisite for
+docz-api's ingestion code, but not a blocker for *starting* docz-api. Per
+INV-0005 Decision 8 (thin vertical slice), docz-api can begin against a
+hand-pinned local `replace` of docz during prototyping; cut the real tag (step
+5) before docz-api's first non-prototype release so it pins a published version.
+The move itself is low-risk and can land immediately — it ships value to the CLI
+repo (a cleaner public surface) independent of docz-api's timeline.
+
+**Rollback:** the move is a pure code relocation behind a single release tag; if
+a problem surfaces, reverting the PR restores the prior `internal/` layout with
+no data or config migration to undo.
+
+## Open Questions
+
+### 1. What is the public package name/path and shape?
+
+- **a. (Recommended)** `pkg/doczcore/config` + `pkg/doczcore/document` — preserve
+  the existing two-package split under a `doczcore` namespace, moving each
+  wholesale with minimal in-file churn and keeping the typed `Status`/`DocType`
+  boundary intact.
+- b. A single flat `pkg/doczcore` merging both — smaller surface, but forces
+  renaming every `config.`/`document.` qualifier across moved + CLI code.
+- c. Promote in place as `pkg/config` + `pkg/document` (no `doczcore` grouping)
+  — shortest paths, but less obvious that they form one "core."
+- d. Other.
+
+### 2. Move wholesale (update all imports) vs. leave permanent re-export shims?
+
+- **a. (Recommended)** Move wholesale and update every in-repo import; no shim
+  survives the release. One canonical path, no rot.
+- b. Move + permanent type-alias shims at `internal/config` /
+   `internal/document` so existing imports never change.
+- c. Move + *transitional* shim inside one PR, deleted before release, only if
+  the import sweep is too large to land atomically.
+- d. Other.
+
+### 3. Add `docz export --json` now, or defer it?
+
+- **a. (Recommended)** Defer. Decision 7 chose the library as primary; ship the
+  promotion first and add `export` only when a concrete non-Go consumer appears.
+- b. Ship `docz export --json` in the same release as the promotion, as a
+  convenience + debugging aid, accepting its JSON shape as a new golden surface.
+- c. Never add it — the library plus the existing `docz list --format json`
+  cover the need.
+- d. Other.
+
+### 4. Module/versioning strategy?
+
+- **a. (Recommended)** Same module, new `pkg/doczcore` path; tag a normal minor
+  `vX.Y.0` and let docz-api pin it. Stay in the current major; cut `v1.0.0` only
+  when the broader CLI is ready, not solely because of this surface.
+- b. Cut `v1.0.0` now precisely *because* promotion creates a public API that
+  deserves an explicit stability guarantee.
+- c. Split the core into a *separate* module
+  (`github.com/donaldgifford/docz-core`) with its own version line, decoupling
+  library semver from CLI releases.
+- d. Other.
+
+### 5. How much surface to expose?
+
+- **a. (Recommended)** Minimal: config (`Load`/`Validate`/resolution/
+  `EnabledTypes`/`TypeDir`) + document (`ScanDocuments`/`LoadFrontmatter`/
+  `ParseFrontmatter`/`IsDoczFile`) + the structs and sentinels. Smallest semver
+  obligation.
+- b. Broader: also promote `SetStatus` and its sentinels so a future
+  write-capable consumer can mutate status through the shared library.
+- c. Broadest: also promote template/index/toc/wiki so a renderer-less consumer
+  could reproduce docz output too (large, ongoing semver cost).
+- d. Other.
+
+### 6. If `docz export` ships, what is the manifest schema shape?
+
+- **a. (Recommended)** One top-level object `{schema_version, docs_dir, types[],
+  documents[]}`, `documents` sorted by `(type, id)`, raw markdown omitted by
+  default (opt-in via `--content`).
+- b. Two separate top-level arrays / NDJSON streaming for very large repos.
+- c. Mirror docz-api's eventual Postgres row shape exactly so ingest is a direct
+  load.
+- d. Other.
+
+### 7. Does docz-api vendor a docz checkout or always consume the library via go.mod?
+
+- **a. (Recommended)** Always consume `pkg/doczcore` as a normal `go.mod`
+  dependency pinned to a tag; no vendored source, no shelling out.
+- b. Additionally `go mod vendor` docz for hermetic, network-free builds, still
+  via the public import path.
+- c. Vendor a full docz checkout and shell out to the binary (INV-0005 option 3)
+  — rejected by Decision 7, listed only for completeness.
+- d. Other.
+
+### 8. Where does the consumer import smoke test live?
+
+- **a. (Recommended)** A separate minimal module under `test/consumer/` with its
+  own `go.mod`, importing the published-style path — the truest proof an
+  external module can import and scan.
+- b. An in-repo peer-package test exercising the public API — simpler CI wiring,
+  slightly weaker "external" guarantee.
+- c. Both — in-repo test for fast feedback, plus a periodic external-module CI
+  job.
+- d. Other.
+
+## References
+
+- **INV-0005** — *docz-api and docz-site: centralized cross-repo docz registry
+  and viewer* — the source investigation; Decision 7 (shared `pkg/…` library)
+  drives this design, and Observation 4 enumerates the library-vs-export-vs-shell
+  options.
+- **DESIGN-0008** — docz-api (the companion service: GitHub App, ingestion,
+  Postgres registry, webhook refresh, Meilisearch). Consumes `pkg/doczcore`;
+  not in scope here.
+- **DESIGN-0009** — docz-site (the viewer: repos → types → docs nav, search,
+  client-side markdown render per INV-0005 Decision 3). Not in scope here.
+- **DESIGN-0006** — *Custom Document Type Support* — establishes that the type
+  set is config-driven and type-agnostic; the promoted `EnabledTypes` /
+  `resolveType` surface must preserve that for the registry.
+- **Code being promoted:**
+  - `internal/config` — `Config`, `TypeConfig`, `DocType`, `Status`,
+    `DocTypeDef`, `Load`, `Validate`, `DefaultConfig`, `EnabledTypes`,
+    `TypeDir`, `ValidateType`, `resolveType`, `DocTypeNames`, `AllDocTypes`,
+    `LookupDocType`, `ResolveTypeAlias`, `ErrUnknownType`
+    (`config.go`, `doctype.go`, `constants.go`).
+  - `internal/document` — `Frontmatter`, `DocEntry`, `ScanDocuments`,
+    `LoadFrontmatter`, `ParseFrontmatter`, `IsDoczFile`, `SetStatus` (candidate
+    to stay internal), and the sentinels `ErrNoFrontmatter`,
+    `ErrStatusFieldMissing`, `ErrUnsupportedLineEndings`
+    (`document.go`, `scan.go`, `status.go`).

--- a/docs/design/0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md
+++ b/docs/design/0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md
@@ -1,0 +1,881 @@
+---
+id: DESIGN-0008
+title: "docz-api: cross-repo docz registry and ingestion service"
+status: Draft
+author: Donald Gifford
+created: 2026-06-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0008: docz-api: cross-repo docz registry and ingestion service
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-23
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [GitHub App setup and onboarding](#github-app-setup-and-onboarding)
+  - [Ingestion pipeline](#ingestion-pipeline)
+  - [Auth and session model](#auth-and-session-model)
+  - [Search](#search)
+  - [Component / sequence overview](#component--sequence-overview)
+- [API / Interface Changes](#api--interface-changes)
+  - [HTTP / JSON endpoints](#http--json-endpoints)
+  - [Service config surface (environment variables)](#service-config-surface-environment-variables)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+  - [1. REST or GraphQL for the JSON API?](#1-rest-or-graphql-for-the-json-api)
+  - [2. Synchronous ingest or a background worker / queue?](#2-synchronous-ingest-or-a-background-worker--queue)
+  - [3. Where are sessions stored?](#3-where-are-sessions-stored)
+  - [4. How is Okta/Keycloak group → repo authorization configured?](#4-how-is-oktakeycloak-group--repo-authorization-configured)
+  - [5. Webhook retry / idempotency strategy?](#5-webhook-retry--idempotency-strategy)
+  - [6. Add tag/release version snapshots now, or stay HEAD-only?](#6-add-tagrelease-version-snapshots-now-or-stay-head-only)
+  - [7. Multi-org / multi-tenant model?](#7-multi-org--multi-tenant-model)
+  - [8. Meilisearch API-key scoping for any direct site access?](#8-meilisearch-api-key-scoping-for-any-direct-site-access)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+**docz-api** is a small Go backend service that aggregates the documentation
+of many repositories — all of which already use the **docz** CLI — into one
+searchable registry behind a single JSON API. A team running docz in fifteen
+repos has fifteen separate doc trees and no single place to search "all our
+ADRs" or "every Draft design across the org." docz-api closes that gap; its
+companion front end, **docz-site** (DESIGN-0009), renders the registry into a
+browsable, searchable web app.
+
+The service has four responsibilities:
+
+1. **Onboard** repositories through a GitHub App. Installed repos are expected
+   to contain a root `.docz.yaml` (the docz manifest).
+2. **Ingest** each repo's `.docz.yaml` plus its docz documents into a Postgres
+   registry and a Meilisearch index.
+3. **Cache** the raw markdown plus parsed frontmatter/metadata — *not* rendered
+   HTML. Rendering happens client-side in docz-site.
+4. **Refresh** incrementally via webhooks (`push` / `release`) on the default
+   branch, and **serve** a JSON API to docz-site: repos → types → docs, plus
+   search and auth.
+
+This design derives from **INV-0005** (the feasibility investigation that
+concluded docz-api is buildable and meaningfully simpler than a general system
+like rfc-api, because docz standardizes location, structure, and metadata at
+the source). It honors the eight decisions locked there. Crucially, docz-api
+does **not** re-implement docz's parser: it consumes the shared Go parsing
+library extracted from the docz CLI in **DESIGN-0007** (`pkg/config` +
+`pkg/document`), so the registry never drifts from the CLI's own notion of
+"what docz docs exist in this tree."
+
+> **Self-contained note.** This document is copied into the new `docz-api`
+> repository to seed development, so the essential context is restated inline.
+> Two upstream documents are load-bearing but not assumed open: **DESIGN-0007**
+> defines the shared parsing library this service imports; **INV-0005** is the
+> investigation whose locked decisions this design implements.
+
+## Goals and Non-Goals
+
+### Goals
+
+- **Cross-repo registry.** A Postgres store keyed by `(repo, doc_id)` holding
+  every docz document across every onboarded repo, with its frontmatter,
+  cached raw markdown, and `git_sha`.
+- **Type-agnostic ingestion.** The registry is driven entirely by each repo's
+  `.docz.yaml`. Custom docz types (e.g. `frameworks` / `FW-0001`) ingest
+  identically to the six built-ins. The six built-in type names are **never**
+  hardcoded anywhere in the service.
+- **GitHub App onboarding + incremental refresh.** Repos opt in by installing
+  the app; `push` / `release` webhooks on the default branch drive diff-based
+  partial re-ingest; `content_hash` gates redundant work.
+- **Raw-markdown caching, not HTML.** The API serves raw markdown plus
+  metadata (Decisions 2 + 3); docz-site renders to HTML client-side.
+- **Pluggable site-user auth (Decision 6).** Authentication is provider-based:
+  GitHub (default/preferred), Okta, and Keycloak — all three required. The
+  GitHub provider mirrors GitHub repo read-access; Okta/Keycloak map OIDC
+  group/role claims to repos via service config.
+- **Full-text + faceted search.** A Meilisearch index over `title`/`body` with
+  facets on `repo` / `type` / `status` / `author`.
+- **A thin vertical slice first (Decision 8).** One hand-onboarded repo →
+  ingest → serve one type, deferring full auth and webhooks, to prove the
+  fetch → parse → upsert → serve loop end to end.
+
+### Non-Goals
+
+- **Rendering markdown to HTML.** No `rendered_html` column, no server-side
+  renderer. Rendering is docz-site's job (Decision 3). The mdp renderer is
+  intentionally scoped to single-user neovim/terminal use and is not a fit for
+  a server-side multi-tenant renderer.
+- **Non-default branches and PR/preview builds.** The default branch HEAD is
+  the single current version (Decisions 4 + 5). Tag/release version snapshots
+  are a possible later extension (Open Question 6).
+- **Re-implementing docz's parser.** Frontmatter and config parsing come from
+  the DESIGN-0007 shared library only (Decision 7).
+- **Building docz-site.** The viewer (nav, reader, client-side rendering) is
+  DESIGN-0009. docz-api is strictly the backend.
+- **Per-repo MkDocs/TechDocs.** docz's existing `wiki` command renders one repo
+  as MkDocs; docz-api is deliberately the complementary cross-repo aggregator,
+  not a replacement for per-repo TechDocs.
+- **Write-back to repos.** docz-api is read-only against GitHub content; it
+  never opens PRs or mutates a source repo.
+
+## Background
+
+docz produces structured docs *per repo*. Each repo has a root `.docz.yaml`
+manifest that declares `docs_dir` and, for every enabled type, its `dir`,
+`id_prefix`, `id_width`, `statuses`, `plural_label`, and `aliases`. Every
+document carries typed, guaranteed frontmatter:
+
+```yaml
+---
+id: RFC-0001
+title: "Some title"
+status: Draft
+author: Jane Dev
+created: 2026-01-15
+---
+```
+
+These three properties make ingestion mechanical rather than heuristic:
+
+- **`.docz.yaml` is a manifest, not a haystack.** The service reads one file
+  and learns exactly where docs live and what types exist — no discovery, and
+  custom types are first-class because the type set is data, not code.
+- **Frontmatter is typed and fixed-shape.** `id`, `title`, `status`, `author`,
+  `created` map almost one-to-one onto a registry row and a search document —
+  no metadata coercion.
+- **IDs are stable and namespaced.** `RFC-0001`, `FW-0003` give a natural
+  per-repo primary key and a clean cross-repo identity `<repo>/<doc_id>`.
+
+The hard part — established in INV-0005 — is **not** docz-specific: a viewer
+aggregating private-repo content must enforce that a site user sees only the
+docs they are allowed to see. INV-0005 split that into **authentication** (who
+is the user, pluggable) and **authorization** (what may they see, per-provider).
+Note the asymmetry that drives the whole design: **ingestion is always via the
+GitHub App** (that is how docz-api reads repo content), independent of how site
+*users* authenticate.
+
+The DESIGN-0007 shared library is what makes the "don't re-implement the
+parser" decision concrete. It promotes the docz CLI's `internal/config`
+(`Load`, `Validate`, type resolution) and `internal/document`
+(`ScanDocuments`, `LoadFrontmatter`) into an importable `pkg/…` surface. Both
+the CLI and docz-api depend on it, so the registry's view of a repo is
+byte-for-byte the CLI's view.
+
+## Detailed Design
+
+### GitHub App setup and onboarding
+
+docz-api is a GitHub App (not an OAuth app for ingestion — see the auth section
+for the separate site-login concern). The app is installed on selected
+repos/orgs and reads content using short-lived installation tokens.
+
+**Required permissions (minimal):**
+
+| Permission       | Level | Why |
+|------------------|-------|-----|
+| `contents`       | read  | Fetch `.docz.yaml` and doc files via the Git Trees/Contents API |
+| `metadata`       | read  | List installed repos, read the default branch |
+
+**Webhook events subscribed:**
+
+| Event                       | Triggers |
+|-----------------------------|----------|
+| `installation`              | App installed/uninstalled → enumerate or purge repos |
+| `installation_repositories` | Repos added/removed from an install → onboard/offboard |
+| `push`                      | Commit to a branch → re-ingest if it is the default branch and touches `docs_dir` or `.docz.yaml` |
+| `release`                   | Release published → reserved for tag/release snapshots (Open Question 6) |
+
+**Installation-token auth flow.** docz-api authenticates to GitHub per request
+chain as follows:
+
+1. Sign a short-lived **app JWT** (RS256) with the App ID and the app private
+   key (`iss` = app id, `exp` ≤ 10 min).
+2. Exchange it for an **installation access token** via
+   `POST /app/installations/{installation_id}/access_tokens`. The token is
+   scoped to that installation's repos and expires in ~1 hour.
+3. Cache the installation token per `installation_id` until just before
+   expiry; refresh on demand.
+4. Use the installation token as a `Bearer` credential on Git Trees / Contents
+   API calls.
+
+**Onboarding.** On `installation` / `installation_repositories`, docz-api
+enumerates the installation's repos (`GET /installation/repositories`), and for
+each repo checks for a root `.docz.yaml`. If present, it inserts an
+`installations` row and a `repos` row and enqueues a full ingest. If absent,
+the repo is recorded but marked unconfigured (no docz manifest) and skipped.
+
+**Webhook HMAC verification.** Every inbound webhook is verified before any
+work:
+
+- The app is configured with a webhook secret.
+- GitHub signs the raw request body with HMAC-SHA256 and sends
+  `X-Hub-Signature-256: sha256=<hex>`.
+- docz-api recomputes `HMAC-SHA256(secret, raw_body)` and compares with
+  `hmac.Equal` (constant-time). A mismatch returns `401` and the payload is
+  dropped. The `X-GitHub-Delivery` id is logged for idempotency (see Open
+  Question 5).
+
+### Ingestion pipeline
+
+The pipeline is one logical flow with several triggers (initial onboard,
+webhook refresh, manual re-sync). It is type-agnostic from end to end: the set
+of types comes from the parsed `.docz.yaml`, never a constant.
+
+```
+ trigger (onboard | push | release | manual)
+        │
+        ▼
+ ┌──────────────────┐   fetch via GitHub Git Trees API (recursive=1)
+ │  Fetcher         │   → resolve default-branch HEAD sha
+ │  (GitHub client) │   → list tree, pull .docz.yaml + docs blobs (no checkout)
+ └────────┬─────────┘
+          │ raw bytes: .docz.yaml + matched *.md
+          ▼
+ ┌──────────────────┐   pkg/config.Load(.docz.yaml) + pkg/config.Validate
+ │  Parser          │   pkg/document.ScanDocuments per enabled type dir
+ │  (DESIGN-0007)   │   → []DocEntry{frontmatter, content, path}
+ └────────┬─────────┘
+          │ config snapshot + parsed doc entries
+          ▼
+ ┌──────────────────┐   compute content_hash per doc (sha256 of raw_md)
+ │  Differ / Gate   │   compare to stored content_hash → changed/new/deleted set
+ └────────┬─────────┘
+          │ changed set only
+          ▼
+ ┌──────────────────┐   upsert repos / doc_types / documents (one tx)
+ │  Postgres Writer │   delete documents absent from this HEAD
+ └────────┬─────────┘
+          │ changed doc ids
+          ▼
+ ┌──────────────────┐   add/replace/delete Meilisearch documents
+ │  Search Indexer  │   keyed by composite "<repo_id>:<doc_id>"
+ └──────────────────┘
+```
+
+**Step detail:**
+
+1. **Fetch (Git Trees API, no checkout — Decision 1).** Resolve the default
+   branch HEAD sha (`GET /repos/{owner}/{name}` → `default_branch`, then the
+   ref). Pull the recursive tree
+   (`GET /repos/{owner}/{name}/git/trees/{sha}?recursive=1`), filter to
+   `.docz.yaml` and blobs under `docs_dir/<type.dir>/`, and fetch each blob
+   (`GET /repos/{owner}/{name}/git/blobs/{blob_sha}`, base64-decoded). This is
+   ideal for typical doc-set sizes; a shallow-clone path is deferred (folded
+   into the background-worker / scaling question).
+
+2. **Parse (DESIGN-0007 library).** `pkg/config.Load` + `Validate` produce the
+   resolved `Config` (which already merges defaults and resolves type aliases /
+   `id_prefix`). For each enabled type, `pkg/document.ScanDocuments(typeDir)`
+   returns `[]DocEntry` with frontmatter and cached `Content`. No parsing logic
+   lives in docz-api.
+
+3. **content_hash gating.** For each doc, `content_hash = sha256(raw_md)`. If a
+   stored row has the same `(repo_id, doc_id, content_hash)`, the doc is
+   unchanged and is skipped for both Postgres and Meilisearch. This is the
+   primary cost gate.
+
+4. **Diff-based partial re-ingest on push.** A `push` webhook carries the list
+   of added/modified/removed paths across its commits. docz-api intersects that
+   list with `docs_dir` to decide *whether* to ingest, and to narrow blob
+   fetches to changed files when possible (still validating against the full
+   tree for deletions). Docs present in the registry but absent from the new
+   HEAD tree are **deleted** from Postgres and Meilisearch.
+
+5. **`.docz.yaml` change re-syncs the type set.** If the push touches
+   `.docz.yaml`, docz-api re-parses it and reconciles `doc_types`: types added
+   to the config are created, removed types (and their orphaned `documents`)
+   are deleted, and changed `statuses` / `plural_label` / `dir` are updated.
+   Because the type set is config-driven, a repo adding a custom `frameworks`
+   type "just works" on the next push.
+
+6. **Debounce.** Rapid successive pushes to the same repo (e.g. a squash-merge
+   followed by a tag) are coalesced: an ingest job for a repo that already has
+   a pending job is collapsed, and a per-repo debounce window
+   (`INGEST_DEBOUNCE`, default a few seconds) batches bursts so the latest HEAD
+   wins.
+
+7. **Upsert + index transactionally on the Postgres side.** The `documents`
+   upsert and `doc_types` reconcile run in one DB transaction; the Meilisearch
+   update follows commit. If indexing fails after commit, the doc's
+   `content_hash` is recorded so a reconcile job can re-index without a full
+   re-ingest (eventual consistency; the search index trails Postgres briefly).
+
+### Auth and session model
+
+Two independent identity concerns, kept strictly separate (INV-0005 Decision 6):
+
+- **Ingestion identity** is **always** the GitHub App installation token,
+  regardless of how site users log in. Nothing in this section changes that.
+- **Site-user identity** is **pluggable** across three providers, behind one
+  abstraction.
+
+**Provider abstraction.** A single Go interface keeps the three providers
+configurable rather than forked:
+
+```go
+// Provider authenticates a site user (the "who") and reports which onboarded
+// repos that user may read (the "what"). Both halves are provider-specific.
+type Provider interface {
+    Name() string                       // "github" | "okta" | "keycloak"
+    AuthCodeURL(state string) string    // begin OAuth/OIDC
+    Exchange(ctx context.Context, code string) (*Identity, error)
+    // AuthorizedRepos returns the repo ids (or "*") this identity may read.
+    AuthorizedRepos(ctx context.Context, id *Identity) ([]int64, error)
+}
+
+type Identity struct {
+    Provider string
+    Subject  string   // stable per-provider user id
+    Email    string
+    Login    string   // github login, when present
+    Groups   []string // OIDC group/role claims (okta/keycloak)
+    Token    string   // provider access token, for live repo checks
+}
+```
+
+**OIDC / OAuth flow.** Standard authorization-code flow on three endpoints
+(see API section): `/auth/login?provider=…` redirects to the provider's
+`AuthCodeURL` with a signed `state`; the provider redirects back to
+`/auth/callback`; docz-api calls `Exchange`, then `AuthorizedRepos`, issues a
+session, and sets a session cookie. GitHub uses OAuth; Okta and Keycloak use
+standard OIDC discovery (`issuer`, `client_id`, `client_secret`, scopes).
+
+**Per-provider authorization** (the half that differs):
+
+- **GitHub provider (default/preferred).** Mirror GitHub repo read-access. A
+  user sees an onboarded repo only if their GitHub token can read it. docz-api
+  checks `GET /repos/{owner}/{name}` (or the user's installation repos) per
+  session and caches the allowed-repo set for the session TTL. This is the
+  tightest, most natural mapping.
+- **Okta / Keycloak providers.** There is no GitHub repo-permission signal, so
+  authorization comes from **OIDC group/role claims** mapped to repos or
+  repo-groups in service config — e.g. `group:platform → [repos…]`. For
+  internal deployments a coarse mode is allowed: *any authenticated member sees
+  all onboarded repos*. The mapping is service config, not code (see Open
+  Question 4).
+
+**Enforcement on read endpoints.** Every read endpoint resolves the session's
+allowed-repo set and filters results to it. List endpoints return only
+authorized repos/docs; a doc fetch for an unauthorized repo returns `404` (not
+`403`, to avoid leaking existence). Search queries are constrained with a
+`repo IN (allowed…)` Meilisearch filter injected server-side so the index can
+never leak across the authorization boundary. In the thin vertical slice
+(Decision 8) auth is stubbed to a single "all repos visible" provider; the
+enforcement seam exists from day one so turning on real providers is additive.
+
+### Search
+
+Meilisearch holds one `documents` index. Each Postgres document maps to one
+Meilisearch document (shape in the Data Model section). Configuration:
+
+- **Searchable attributes:** `title`, `body` (the raw markdown, indexed as
+  text). `title` is ranked above `body`.
+- **Filterable attributes (facets):** `repo`, `type`, `status`, `author`. These
+  drive cross-repo filtered views — "all Approved designs across repos" is a
+  facet query, not custom code — and back the per-session `repo IN (…)`
+  authorization filter.
+- **Sortable attributes:** `created`, `updated_at`.
+- **Primary key:** a composite string `id = "<repo_id>:<doc_id>"` so the same
+  `RFC-0001` in two repos never collides.
+
+Indexing is keyed off the same content_hash gate as Postgres: unchanged docs
+are not re-indexed; deleted docs are removed by primary key. Search results
+return enough metadata (repo, type, doc_id, title, status, snippet) for
+docz-site to render a result list and link to the full doc fetch.
+
+### Component / sequence overview
+
+```
+                          ┌───────────────────────────────────────────┐
+   GitHub  ── webhook ───▶ │                docz-api (Go)               │
+   (App)   ◀─ Trees API ── │                                           │
+                          │  ┌──────────┐   ┌──────────┐  ┌─────────┐  │
+                          │  │ Webhook  │──▶│ Ingest   │─▶│ Search  │──┼─▶ Meilisearch
+                          │  │ handler  │   │ pipeline │  │ indexer │  │
+                          │  └──────────┘   └────┬─────┘  └─────────┘  │
+                          │                      │                     │
+                          │                      ▼                     │
+                          │                 ┌─────────┐                │
+                          │                 │ Postgres│◀──── reads ────┤
+                          │                 │ registry│                │
+   docz-site ── HTTP ────▶ │  ┌──────────┐  └─────────┘                │
+   (DESIGN-0009)         │  │ JSON API │──── auth (Provider) ──────────┼─▶ GitHub/Okta/Keycloak
+                          │  └──────────┘                              │
+                          └───────────────────────────────────────────┘
+```
+
+**Ingest sequence (push on default branch):**
+
+```
+GitHub        Webhook        Ingest          Parser(pkg)    Postgres   Meili
+  │  push       │              │                  │            │         │
+  ├────────────▶│ verify HMAC  │                  │            │         │
+  │             ├─ default br? touches docs_dir? ─┤            │         │
+  │             ├─────────────▶│ debounce/coalesce│            │         │
+  │             │              ├─ fetch tree+blobs│            │         │
+  │             │              ├─────────────────▶│ Load/Scan  │         │
+  │             │              │◀── []DocEntry ───┤            │         │
+  │             │              ├─ content_hash diff ──────────▶│ upsert  │
+  │             │              │                  │            ├─ commit │
+  │             │              ├─ index changed ──┼────────────┼────────▶│
+  │             │◀─ 202 ───────┤                  │            │         │
+```
+
+## API / Interface Changes
+
+This is a greenfield service, so "interface changes" means the initial HTTP/JSON
+surface plus the config surface. All responses are JSON; all read endpoints are
+authorization-filtered to the session's allowed repos.
+
+### HTTP / JSON endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/healthz` | Liveness/readiness (DB + Meilisearch reachable) |
+| `GET`  | `/api/repos` | List onboarded repos the session may read |
+| `GET`  | `/api/repos/{owner}/{name}` | Repo detail (config snapshot, last_synced_sha) |
+| `GET`  | `/api/repos/{owner}/{name}/types` | List doc types for a repo |
+| `GET`  | `/api/repos/{owner}/{name}/types/{type}/docs` | List docs of a type |
+| `GET`  | `/api/repos/{owner}/{name}/docs/{doc_id}` | Get one doc: raw markdown + metadata |
+| `GET`  | `/api/search?q=&repo=&type=&status=&author=` | Faceted full-text search |
+| `GET`  | `/auth/login?provider={github\|okta\|keycloak}` | Begin OAuth/OIDC |
+| `GET`  | `/auth/callback` | OAuth/OIDC redirect target; issues session |
+| `POST` | `/auth/logout` | Invalidate session |
+| `POST` | `/webhooks/github` | GitHub App webhook receiver (HMAC-verified) |
+
+Notes:
+
+- `{type}` accepts the type's canonical name **or** its `id_prefix` / alias,
+  resolved by the same DESIGN-0007 `Config.resolveType` logic the CLI uses, so
+  `…/types/frameworks/docs` and `…/types/FW/docs` are equivalent.
+- `{doc_id}` is the frontmatter id (`RFC-0001`), case-sensitive, matching the
+  CLI's convention.
+- The doc fetch returns **raw markdown** in `raw_md`; docz-site renders it.
+
+**Example — get a document:**
+
+```http
+GET /api/repos/acme/platform/docs/RFC-0001 HTTP/1.1
+Host: docz-api.internal
+Cookie: docz_session=…
+```
+
+```json
+{
+  "repo": "acme/platform",
+  "doc_id": "RFC-0001",
+  "type": "rfc",
+  "title": "Adopt structured logging",
+  "status": "Accepted",
+  "author": "Jane Dev",
+  "created": "2026-01-15",
+  "path": "docs/rfc/0001-adopt-structured-logging.md",
+  "git_sha": "9f1c2ab…",
+  "content_hash": "sha256:7b4e…",
+  "updated_at": "2026-06-22T18:04:11Z",
+  "raw_md": "---\nid: RFC-0001\ntitle: \"Adopt structured logging\"\n…\n---\n\n# RFC 0001 …"
+}
+```
+
+**Example — search:**
+
+```http
+GET /api/search?q=logging&type=rfc&status=Accepted HTTP/1.1
+Host: docz-api.internal
+Cookie: docz_session=…
+```
+
+```json
+{
+  "query": "logging",
+  "estimated_total_hits": 2,
+  "hits": [
+    {
+      "repo": "acme/platform",
+      "doc_id": "RFC-0001",
+      "type": "rfc",
+      "title": "Adopt structured logging",
+      "status": "Accepted",
+      "author": "Jane Dev",
+      "snippet": "…adopt <em>structured logging</em> across services…"
+    }
+  ],
+  "facets": {
+    "repo":   { "acme/platform": 2 },
+    "type":   { "rfc": 2 },
+    "status": { "Accepted": 1, "Draft": 1 }
+  }
+}
+```
+
+### Service config surface (environment variables)
+
+```env
+# Postgres
+DATABASE_URL=postgres://docz:secret@db:5432/docz_api?sslmode=require
+
+# Meilisearch
+MEILI_HOST=http://meili:7700
+MEILI_API_KEY=…                # admin/index key; site uses a scoped key (see OQ 8)
+
+# GitHub App (ingestion — always GitHub, regardless of site auth)
+GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY=/run/secrets/docz_app.pem   # PEM path or PEM body
+GITHUB_WEBHOOK_SECRET=…
+GITHUB_API_BASE=https://api.github.com             # override for GHES
+
+# Site auth providers (pluggable; enable one or more)
+AUTH_PROVIDERS=github,okta,keycloak                # comma-separated; default "github"
+SESSION_SECRET=…                                   # signs session cookies
+
+# GitHub OAuth (site login)
+GITHUB_OAUTH_CLIENT_ID=…
+GITHUB_OAUTH_CLIENT_SECRET=…
+
+# Okta (OIDC)
+OKTA_ISSUER=https://acme.okta.com/oauth2/default
+OKTA_CLIENT_ID=…
+OKTA_CLIENT_SECRET=…
+OKTA_GROUP_REPO_MAP=/etc/docz-api/okta-groups.yaml  # group -> repos[] mapping
+
+# Keycloak (OIDC)
+KEYCLOAK_ISSUER=https://kc.acme.com/realms/acme
+KEYCLOAK_CLIENT_ID=…
+KEYCLOAK_CLIENT_SECRET=…
+KEYCLOAK_GROUP_REPO_MAP=/etc/docz-api/keycloak-groups.yaml
+
+# Ingestion tuning
+INGEST_DEBOUNCE=5s
+```
+
+The group→repo mapping files (referenced for Okta/Keycloak) hold the
+authorization config; their exact shape is Open Question 4.
+
+## Data Model
+
+The Postgres schema refines the INV-0005 sketch. All timestamps are
+`timestamptz`. JSONB columns hold the config snapshot and per-type `statuses`
+exactly as parsed, so the registry can answer "what types/statuses did this
+repo declare" without a second source of truth.
+
+```sql
+-- A GitHub App installation (one per org/account that installed the app).
+CREATE TABLE installations (
+    id              BIGINT PRIMARY KEY,            -- GitHub installation id
+    account_login   TEXT        NOT NULL,          -- org or user that installed
+    account_type    TEXT        NOT NULL,          -- 'Organization' | 'User'
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- An onboarded repository. config_snapshot is the parsed .docz.yaml.
+CREATE TABLE repos (
+    id               BIGSERIAL PRIMARY KEY,
+    installation_id  BIGINT      NOT NULL REFERENCES installations(id) ON DELETE CASCADE,
+    owner            TEXT        NOT NULL,
+    name             TEXT        NOT NULL,
+    default_branch   TEXT        NOT NULL,
+    docs_dir         TEXT        NOT NULL,          -- from .docz.yaml
+    config_snapshot  JSONB       NOT NULL,          -- full parsed .docz.yaml
+    last_synced_sha  TEXT,                          -- default-branch HEAD last ingested
+    last_synced_at   TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (owner, name)
+);
+
+-- Per-repo doc types, driven entirely by .docz.yaml (custom types included).
+CREATE TABLE doc_types (
+    id            BIGSERIAL PRIMARY KEY,
+    repo_id       BIGINT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    name          TEXT   NOT NULL,                  -- canonical, e.g. 'rfc','frameworks'
+    dir           TEXT   NOT NULL,                  -- e.g. 'rfc'
+    id_prefix     TEXT   NOT NULL,                  -- e.g. 'RFC','FW'
+    plural_label  TEXT   NOT NULL,                  -- display label
+    statuses      JSONB  NOT NULL,                  -- ["Draft","Accepted",…]
+    aliases       JSONB  NOT NULL DEFAULT '[]',     -- per-type CLI shorthands
+    UNIQUE (repo_id, name)
+);
+
+-- One row per docz document at the default-branch HEAD.
+CREATE TABLE documents (
+    id            BIGSERIAL PRIMARY KEY,
+    repo_id       BIGINT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    type          TEXT   NOT NULL,                  -- canonical type name
+    doc_id        TEXT   NOT NULL,                  -- frontmatter id, e.g. 'RFC-0001'
+    title         TEXT   NOT NULL,
+    status        TEXT,
+    author        TEXT,
+    created       DATE,                             -- frontmatter created
+    path          TEXT   NOT NULL,                  -- repo-relative path
+    git_sha       TEXT   NOT NULL,                  -- blob sha of the file
+    content_hash  TEXT   NOT NULL,                  -- sha256 of raw_md (re-ingest gate)
+    raw_md        TEXT   NOT NULL,                  -- cached markdown (NOT html)
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo_id, doc_id)
+);
+
+CREATE INDEX documents_repo_type_idx ON documents (repo_id, type);
+CREATE INDEX documents_status_idx    ON documents (status);
+
+-- Site users (one row per provider identity that has logged in).
+CREATE TABLE users (
+    id           BIGSERIAL PRIMARY KEY,
+    provider     TEXT NOT NULL,                     -- 'github' | 'okta' | 'keycloak'
+    subject      TEXT NOT NULL,                     -- stable per-provider id
+    email        TEXT,
+    login        TEXT,                              -- github login when present
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (provider, subject)
+);
+
+-- Server-side sessions (default storage; see Open Question 3 for alternatives).
+CREATE TABLE sessions (
+    id              TEXT PRIMARY KEY,               -- opaque session id (cookie value)
+    user_id         BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider        TEXT   NOT NULL,
+    allowed_repos   JSONB  NOT NULL,                -- cached repo ids, or "*"
+    groups          JSONB  NOT NULL DEFAULT '[]',   -- OIDC group/role claims
+    expires_at      TIMESTAMPTZ NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX sessions_user_idx    ON sessions (user_id);
+CREATE INDEX sessions_expires_idx ON sessions (expires_at);
+```
+
+Per-provider authorization config (the group→repo mapping for Okta/Keycloak) is
+deliberately **not** a table in the thin slice — it is env-driven / file-driven
+service config (the `*_GROUP_REPO_MAP` files above), so operators can manage it
+with the rest of their deployment config. Promoting it to a table (e.g.
+`repo_groups`) is reasonable later; it is folded into Open Question 4.
+
+**Meilisearch document shape.** One Meilisearch document per `documents` row:
+
+```json
+{
+  "id": "42:RFC-0001",
+  "repo": "acme/platform",
+  "repo_id": 42,
+  "doc_id": "RFC-0001",
+  "type": "rfc",
+  "title": "Adopt structured logging",
+  "status": "Accepted",
+  "author": "Jane Dev",
+  "created": "2026-01-15",
+  "body": "# RFC 0001 … full raw markdown body for full-text search …",
+  "updated_at": 1750615451
+}
+```
+
+- `id` is the composite primary key `<repo_id>:<doc_id>`.
+- `title` + `body` are searchable; `repo` / `type` / `status` / `author` are
+  filterable facets; `created` / `updated_at` are sortable.
+
+## Testing Strategy
+
+- **Unit — parsing / ingest mapping.** Given fixture bytes for `.docz.yaml` and
+  a set of `*.md` docs, assert the parse (via the DESIGN-0007 library) → row
+  mapping is correct: frontmatter → `documents` columns, types → `doc_types`,
+  `content_hash` stable for identical bytes and changed when content changes.
+  Include a **custom type** fixture (`frameworks` / `FW-0001`) to prove no
+  built-in is hardcoded, and a doc *missing* frontmatter to prove it is skipped
+  without aborting the repo.
+
+- **Integration — Postgres + Meilisearch + webhook handlers.** Spin Postgres
+  and Meilisearch with **testcontainers-go** (or an equivalent harness). Cover:
+  full ingest of a fixture tree; a second ingest with one changed doc (only the
+  changed row re-written, content_hash gate proven); a `.docz.yaml` change that
+  adds/removes a type (reconcile path); a doc deletion (row + index entry
+  removed). Drive these through the webhook handler with synthetic `push`
+  payloads so the trigger path is exercised, not just the inner pipeline.
+
+- **Webhook signature tests.** Table-driven HMAC-SHA256 cases: a correct
+  `X-Hub-Signature-256` passes; a wrong secret, a tampered body, and a missing
+  header all return `401` and perform no DB writes. Assert constant-time
+  comparison is used (no early-exit on first byte).
+
+- **End-to-end onboarding.** A fixture repo (committed under `testdata/`, served
+  through a recorded/replayed GitHub client) is onboarded start to finish:
+  `installation` event → enumerate → detect `.docz.yaml` → full ingest → assert
+  `/api/repos`, `/api/repos/.../types`, and a doc fetch return the expected
+  shapes. The GitHub Trees/Contents calls are replayed from recorded fixtures so
+  the test is hermetic.
+
+- **Auth enforcement.** With a stub `Provider` returning a fixed allowed-repo
+  set, assert list endpoints filter to authorized repos, an unauthorized doc
+  fetch returns `404`, and the search filter injects `repo IN (allowed…)` so an
+  out-of-scope doc never appears in results.
+
+- **Golden / fixture discipline.** Reuse the docz convention: fixture trees and
+  expected JSON under `testdata/`, regenerated with an `-update` flag, never
+  hand-edited.
+
+## Migration / Rollout Plan
+
+docz-api is a **greenfield repository**; this document is its seed design. There
+is no in-place migration of an existing system — "rollout" is the order in which
+the service is built and shipped.
+
+1. **Tagged docz library dependency (DESIGN-0007).** docz-api's `go.mod`
+   depends on a **tagged release** of the docz module exposing `pkg/config` +
+   `pkg/document`. This is a hard prerequisite: the slice cannot parse a repo
+   without it. The dependency is version-pinned so a docz CLI change cannot
+   silently alter ingestion; bumps are deliberate.
+
+2. **Thin vertical slice first (Decision 8).** Ship the smallest end-to-end
+   loop: one **hand-onboarded** repo (its `installation_id` / `owner` / `name`
+   seeded directly, no GitHub App install UX) → fetch via Trees API → parse →
+   upsert Postgres → serve `/api/repos`, one `/types`, and a doc fetch. **Auth
+   is stubbed** to a single "all repos visible" provider and **webhooks are
+   deferred** (re-ingest is a manual endpoint or CLI subcommand). This proves
+   fetch → parse → upsert → serve before any of the harder subsystems.
+
+3. **DB migrations.** Schema is managed by a migration tool (e.g. `goose` or
+   `golang-migrate`) checked into the repo; `migrate up` runs on deploy.
+   Migrations are forward-only and additive where possible so a binary rollback
+   does not require a destructive down-migration.
+
+4. **Layer in the rest.** In order: real GitHub App onboarding +
+   installation-token flow; the webhook receiver (HMAC + `push`/`release`); the
+   content_hash-gated diff/debounce pipeline; the Meilisearch indexer; then the
+   pluggable auth providers (GitHub first, then Okta/Keycloak) with real
+   per-provider authorization enforcement.
+
+5. **Container / deploy.** A single Go binary in a minimal container image,
+   plus Postgres and Meilisearch (managed services or sidecar containers). The
+   service is stateless except for its DB and search index, so it scales
+   horizontally behind a load balancer; webhook delivery to any replica is fine
+   because ingest jobs reconcile against the stored `last_synced_sha`. Secrets
+   (app private key, webhook secret, OIDC client secrets, Meilisearch key) come
+   from the platform's secret store via the env vars above.
+
+6. **Then docz-site (DESIGN-0009)** consumes the JSON API. The site is built
+   against the slice's endpoints from the start so the contract is exercised
+   early.
+
+## Open Questions
+
+### 1. REST or GraphQL for the JSON API?
+
+- **a. (Recommended)** Plain REST/JSON as specified above. The resource shape
+  (repos → types → docs + search) is shallow and well-bounded; REST keeps the
+  server simple, is trivially cacheable, and is enough for docz-site's needs.
+- b. GraphQL — one flexible endpoint lets docz-site shape exactly the data it
+  needs and avoids over-fetching across the nav tree.
+- c. REST now, add a GraphQL gateway later only if the site's query patterns
+  prove awkward.
+- Other.
+
+### 2. Synchronous ingest or a background worker / queue?
+
+- **a. (Recommended)** Background worker. Webhooks enqueue an ingest job and
+  return `202` immediately; a worker (in-process queue first, durable queue
+  later) does fetch/parse/upsert/index. Keeps webhook handling fast and lets
+  debounce/coalesce live in one place. Also where a future shallow-clone path
+  for very large repos would land.
+- b. Fully synchronous ingest inside the webhook handler — simplest for the
+  thin slice, but risks GitHub webhook timeouts on large repos.
+- c. External queue (e.g. a Postgres-backed job table, NATS, or SQS) from day
+  one for durability and retry.
+- Other.
+
+### 3. Where are sessions stored?
+
+- **a. (Recommended)** Postgres `sessions` table (as schematized). One store to
+  operate, supports server-side revocation, and the cached allowed-repo set
+  lives next to it.
+- b. Redis — faster session reads and natural TTL eviction, at the cost of a
+  second datastore.
+- c. Stateless signed JWT cookies — no session store, but revocation and
+  refreshing the cached allowed-repo set become awkward.
+- Other.
+
+### 4. How is Okta/Keycloak group → repo authorization configured?
+
+- **a. (Recommended)** A service-config mapping file per provider
+  (`*_GROUP_REPO_MAP`) of `group → [repos…]`, hot-reloadable, plus a coarse
+  "any authenticated member sees all" toggle for internal deployments.
+- b. Database-backed `repo_groups` tables managed through an admin API — more
+  operable at scale, more to build.
+- c. Encode the mapping directly in OIDC claims (a custom claim listing repo
+  slugs) so the provider owns it entirely.
+- Other.
+
+### 5. Webhook retry / idempotency strategy?
+
+- **a. (Recommended)** Idempotency on `X-GitHub-Delivery`: record processed
+  delivery ids and reconcile ingest against `last_synced_sha`, so a replayed or
+  duplicate delivery is a no-op. Rely on GitHub's own redelivery for transient
+  failures.
+- b. A durable job table with explicit retry/backoff and a dead-letter for
+  poison deliveries.
+- c. At-least-once with no dedup, accepting that the content_hash gate makes
+  re-ingest cheap and mostly harmless.
+- Other.
+
+### 6. Add tag/release version snapshots now, or stay HEAD-only?
+
+- **a. (Recommended)** Stay HEAD-only for now (honors Decision 4): the default
+  branch HEAD is the single current version, `git_sha` is stored per doc, and
+  the `release` webhook is wired but only logged. Add snapshots later behind a
+  schema extension.
+- b. Add a `doc_versions` table now and snapshot on `release`, paying the
+  storage/complexity cost up front.
+- c. Keep full per-doc history (every HEAD change) rather than just tagged
+  snapshots.
+- Other.
+
+### 7. Multi-org / multi-tenant model?
+
+- **a. (Recommended)** Single logical tenant per deployment; multiple GitHub
+  installations (orgs) coexist in one registry, separated only by
+  authorization. Simplest, and fits the "one team, many repos" target.
+- b. Hard multi-tenancy with a `tenant_id` on every table and per-tenant
+  isolation — needed only if docz-api is offered as a shared/hosted service.
+- c. One deployment per org, no cross-org concept at all.
+- Other.
+
+### 8. Meilisearch API-key scoping for any direct site access?
+
+- **a. (Recommended)** docz-site never talks to Meilisearch directly; all
+  search goes through docz-api with a server-side `repo IN (allowed…)` filter,
+  and only the API holds the Meilisearch admin/index key. No key reaches the
+  browser.
+- b. Issue Meilisearch **tenant tokens** (scoped, short-lived, with an embedded
+  filter) so docz-site can query Meilisearch directly for lower latency, at the
+  cost of trusting the embedded filter.
+- c. A separate read-only Meilisearch key with no embedded filter, relying on
+  the API to never expose it — weakest option.
+- Other.
+
+## References
+
+- **INV-0005** — *docz-api and docz-site: centralized cross-repo docz registry
+  and viewer.* The feasibility investigation and source of the eight locked
+  decisions this design implements.
+- **DESIGN-0007** — the shared docz parsing library (`pkg/config` +
+  `pkg/document`) extracted from the docz CLI; the hard dependency docz-api
+  imports so its registry never drifts from the CLI (Decision 7).
+- **DESIGN-0009** — *docz-site*, the front-end consumer of this API (nav,
+  search, client-side markdown rendering — Decision 3).
+- **GitHub Apps** — installation tokens, permissions, and webhook delivery:
+  <https://docs.github.com/en/apps>.
+- **GitHub Git Trees API** — recursive tree + blob fetch without a checkout
+  (Decision 1): <https://docs.github.com/en/rest/git/trees>.
+- **GitHub webhook signature verification** — `X-Hub-Signature-256` /
+  HMAC-SHA256:
+  <https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries>.
+- **Meilisearch** — searchable/filterable/sortable attributes, facets, and
+  tenant tokens: <https://www.meilisearch.com/docs>.
+- **OpenID Connect (OIDC)** — authorization-code flow for the Okta/Keycloak
+  providers: <https://openid.net/developers/how-connect-works/>.
+- docz custom document types (registry must be type-agnostic, driven by each
+  repo's `.docz.yaml`) — DESIGN-0006 / IMPL-0012.

--- a/docs/design/0009-docz-site-cross-repo-docz-viewer-and-search-ui.md
+++ b/docs/design/0009-docz-site-cross-repo-docz-viewer-and-search-ui.md
@@ -1,0 +1,709 @@
+---
+id: DESIGN-0009
+title: "docz-site: cross-repo docz viewer and search UI"
+status: Draft
+author: Donald Gifford
+created: 2026-06-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0009: docz-site: cross-repo docz viewer and search UI
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-23
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [Tech stack proposal](#tech-stack-proposal)
+  - [Information architecture and route map](#information-architecture-and-route-map)
+  - [Search UX and how it queries docz-api](#search-ux-and-how-it-queries-docz-api)
+  - [Document reader pipeline](#document-reader-pipeline)
+  - [Auth and session handling against docz-api](#auth-and-session-handling-against-docz-api)
+  - [Loading, empty, and error states](#loading-empty-and-error-states)
+  - [Responsive layout](#responsive-layout)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+  - [1. Which front-end framework?](#1-which-front-end-framework)
+  - [2. Which markdown renderer library?](#2-which-markdown-renderer-library)
+  - [3. SSR or SPA?](#3-ssr-or-spa)
+  - [4. How does the site integrate with Meilisearch search?](#4-how-does-the-site-integrate-with-meilisearch-search)
+  - [5. HTML sanitization approach?](#5-html-sanitization-approach)
+  - [6. Styling / design-system choice?](#6-styling--design-system-choice)
+  - [7. Where does the OIDC/OAuth token exchange happen?](#7-where-does-the-oidcoauth-token-exchange-happen)
+  - [8. How should docz's own ToC markers be handled?](#8-how-should-doczs-own-toc-markers-be-handled)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+**docz-site** is the web front end that lets a team browse, search, and read
+*all* of their docz documents from a single URL. docz is a CLI that generates
+and manages standardized per-repo documentation (RFCs, ADRs, design docs,
+implementation plans, plans, investigations) with typed YAML frontmatter
+(`id`, `title`, `status`, `author`, `created`), stable namespaced IDs
+(`RFC-0001`, `FW-0003`), and a `.docz.yaml` manifest per repo. Today each repo
+has its own doc tree and there is no single place to search "all our ADRs" or
+"every Draft design across the org." docz-site is that single place.
+
+docz-site is a **client** of **docz-api** (designed separately in DESIGN-0008).
+docz-api is a Go service that uses a GitHub App to onboard repos, ingests each
+repo's `.docz.yaml` + doc files into a Postgres registry, indexes them in
+Meilisearch, and refreshes via webhooks. Critically for this design:
+
+- docz-api **caches raw markdown + metadata** (Decision 2). It does *not* store
+  rendered HTML and does *not* render server-side.
+- docz-site therefore **renders markdown → HTML client-side** with a JS
+  renderer (Decision 3). docz's own terminal renderer (`mdp`) is intentionally
+  single-user neovim/terminal scope and is *not* reused here.
+- docz-site **stores no source data** and **never talks to GitHub directly for
+  content** — it reads everything from docz-api over HTTP/JSON.
+
+This document derives from INV-0005 ("docz-api and docz-site: centralized
+cross-repo docz registry and viewer") and honors its locked decisions. It is
+written to seed a brand-new `docz-site` git repository, so it restates the
+essential context rather than assuming the docz or docz-api repos are open.
+
+## Goals and Non-Goals
+
+### Goals
+
+- **One URL for all docz documents.** Navigate repos → a repo → its doc types →
+  the documents of a type → open and read one document, with breadcrumbs
+  throughout.
+- **Global search** (Meilisearch-backed, via docz-api) with facets on **repo**,
+  **type**, **status**, and **author**, and cross-repo views that fall out of
+  those facets (e.g. "all Approved designs across repos").
+- **A faithful document reader.** Fetch raw markdown from docz-api, render it to
+  HTML client-side, **sanitize** the result (it is user content → XSS surface),
+  highlight code, build a table of contents from headings, and show a
+  frontmatter **status badge**.
+- **Pluggable authentication** (Decision 6) via OIDC/OAuth: **GitHub**
+  (default/preferred), **Okta**, **Keycloak**. The user sees only the repos and
+  docs they are authorized for; **authorization is enforced server-side by
+  docz-api**, and the site reflects it.
+- **A thin vertical slice first** (Decision 8): render one repo's one type
+  end-to-end before building the full navigation, search, and auth.
+- **A responsive layout** — sidebar navigation + content area — that degrades to
+  a single column on small screens.
+
+### Non-Goals
+
+- **Authoring or editing documents.** docz-site is read-only; docs are created
+  and mutated by the docz CLI in their source repos.
+- **Storing or persisting source data.** No database; the site is a thin client
+  over docz-api. (A bounded client-side query cache is in scope; durable storage
+  is not.)
+- **Talking to GitHub for content.** Repo content always comes from docz-api.
+  The GitHub App is docz-api's concern (DESIGN-0008); the site only uses GitHub
+  as one *identity* provider.
+- **Server-side markdown rendering** (rejected by Decision 3) and **reusing
+  `mdp`** (its scope is single-user terminal preview).
+- **Replacing per-repo MkDocs/TechDocs.** docz's per-repo `wiki` output is for
+  deep single-project browsing; docz-site is the org-wide cross-repo index. They
+  are complementary.
+- **Implementing the authorization policy.** docz-site renders what docz-api
+  returns; the policy (GitHub repo access vs. OIDC group claims) lives in
+  docz-api.
+
+## Background
+
+The viewer half of INV-0005 settled on a shape that this design fills in. The
+load-bearing conclusions:
+
+- **The site is a thin client.** All discovery, normalization, caching, and
+  search live behind docz-api. The site's job is navigation, search UX, and a
+  good reader.
+- **Markdown is rendered in the browser** (Decision 3). docz-api hands the site
+  raw markdown plus the parsed frontmatter; the site owns the
+  parse → render → sanitize → highlight → ToC pipeline. This keeps docz-api free
+  of an HTML rendering stack and lets the reader evolve independently of the
+  ingest service.
+- **Auth is pluggable, authZ is server-enforced** (Decision 6). The site lets a
+  user log in through one of several providers, but it never decides *what* a
+  user may see — every content endpoint on docz-api is already access-scoped, so
+  an unauthorized repo simply does not appear in the API's responses. The site
+  must therefore treat 401/403 as first-class states, not edge cases.
+- **Cross-repo views are free.** Because Meilisearch facets on repo/type/status/
+  author, a view like "all Approved designs" is just a faceted search query — no
+  special endpoint or UI mode.
+
+What this design adds on top of INV-0005 is the concrete front-end shape: tech
+stack, information architecture and routes, search UX, the reader pipeline, auth
+and session handling against docz-api, the standard loading/empty/error states,
+and the responsive layout.
+
+## Detailed Design
+
+### Tech stack proposal
+
+docz-site is a JavaScript/TypeScript single-page application (or SSR app — see
+Open Question 3). The working recommendation, to be confirmed:
+
+| Concern             | Recommendation                          | Notes                                                            |
+|---------------------|------------------------------------------|------------------------------------------------------------------|
+| Framework           | React + Vite SPA (or Next.js)            | Exact choice is Open Question 1; SSR vs SPA is Open Question 3    |
+| Language            | TypeScript (strict)                      | View-model interfaces below are the contract with docz-api       |
+| Routing             | File- or config-based router             | Route map below                                                  |
+| Data fetching/cache | TanStack Query                           | Request dedup, caching, retries, stale-while-revalidate          |
+| Markdown render     | `markdown-it` **or** `react-markdown`    | Open Question 2                                                   |
+| HTML sanitization   | DOMPurify                                | Mandatory; see reader pipeline (Open Question 5)                 |
+| Syntax highlight    | Shiki **or** highlight.js                | Build the highlighted HTML, then sanitize                        |
+| Styling             | Tailwind + a small component set         | Open Question 6                                                  |
+| E2E tests           | Playwright                               | Against a mocked/fixture docz-api                                |
+| Unit/component      | Vitest + Testing Library                 | Includes the XSS sanitization suite                              |
+
+The recommendation is a **Vite + React SPA** for the thin vertical slice: no
+server runtime to operate, fastest path to "render one repo's one type," and a
+clean separation where docz-api is the only backend. SSR (Next.js/SvelteKit) is
+attractive later for SEO-able public docs, faster first paint, and a place to
+run a BFF token exchange (see Open Question 7) — hence keeping the framework
+choice open rather than locking it now.
+
+### Information architecture and route map
+
+Navigation mirrors the docz mental model from INV-0005: **repos → a repo → its
+doc types → a document**, with a global search surface alongside.
+
+```
+/                               Landing / dashboard (recent + entry points)
+/repos                          List of onboarded repos the user may see
+/:owner/:repo                   Repo detail: the repo's doc types
+/:owner/:repo/:type             List of documents of one type in the repo
+/:owner/:repo/:type/:docId      Single document reader (e.g. .../design/DESIGN-0009)
+/search                         Global faceted search (repo/type/status/author)
+/login                          Provider selection / OIDC entry point
+/auth/callback                  OAuth/OIDC redirect handler
+*                               404 / not-found
+```
+
+Notes on the route shape:
+
+- `:owner/:repo` together identify a repo (e.g. `acme/platform`); this matches
+  docz-api's `{owner}/{repo}` addressing and reads naturally in breadcrumbs.
+- `:type` is the docz type *name or id_prefix* as docz-api exposes it
+  (`design`, `rfc`, or a custom `frameworks`). The registry is **type-agnostic**
+  — driven entirely by each repo's `.docz.yaml`, never a hardcoded list of the
+  six built-ins — so the site must render whatever types the API returns.
+- `:docId` is the stable frontmatter id (`DESIGN-0009`). It is unique within a
+  repo, so `(owner, repo, docId)` is a stable permalink.
+- **Cross-repo views are URLs into `/search`**, not new routes. "All Approved
+  designs across repos" is `/search?type=design&status=Approved` with no `repo`
+  facet selected. This keeps the IA small and makes every view shareable.
+
+**Breadcrumbs** are derived from the route everywhere below `/repos`:
+
+```
+Repos / acme/platform / Designs / DESIGN-0009
+```
+
+### Search UX and how it queries docz-api
+
+Search is the primary cross-repo surface. The `/search` page has:
+
+- A query box (debounced, ~200 ms) bound to the URL `?q=`.
+- A **facets sidebar** with four groups — repo, type, status, author — each a
+  multi-select list of values with hit counts, bound to URL params
+  (`?repo=…&type=…&status=…&author=…`). Selecting facets is additive and
+  reflected in the URL so a filtered view is a shareable link.
+- A results list of **search hits**: title, repo, type badge, status badge,
+  author, and a highlighted snippet; clicking a hit routes to the document
+  reader.
+
+Every search interaction is one request to docz-api's search endpoint
+(`GET /api/v1/search`, below), which proxies to Meilisearch. **Whether the site
+hits a docz-api proxy endpoint or talks to Meilisearch directly with a scoped
+search key is Open Question 4.** The recommendation is to proxy through docz-api
+so that (a) the same access scoping that filters content endpoints also filters
+search results, (b) no Meilisearch key is exposed to the browser, and (c) the
+site has exactly one backend. The direct-Meilisearch alternative buys lower
+latency and Meilisearch's instant-search components at the cost of issuing
+per-session scoped keys and trusting the browser with filter constraints.
+
+Because facets come straight from Meilisearch, **cross-repo views are search
+queries** (see IA above): the `/search` page *is* the cross-repo view engine,
+and the repo/type pages are just pre-filtered entry points into it.
+
+### Document reader pipeline
+
+The reader is the heart of the site and the part the thin vertical slice proves
+first. docz-api returns **raw markdown + parsed metadata**; the site does
+everything else, in this fixed order:
+
+```
+1. fetch          GET .../:type/:docId  → { metadata, raw_md } from docz-api
+2. parse FM       split frontmatter from body (api already parsed metadata;
+                  the body is the markdown below the --- block)
+3. render md      markdown → HTML via the chosen JS renderer (OQ 2)
+4. sanitize       HTML → safe HTML via DOMPurify (MANDATORY; see below)
+5. highlight      syntax-highlight code blocks (then ensure step 4 covered it)
+6. build ToC      walk rendered headings → nested ToC; add anchor ids
+7. status badge   render frontmatter status as a colored badge
+```
+
+Two ordering rules are load-bearing:
+
+- **Sanitization is non-negotiable and runs after rendering.** The content is
+  user-authored markdown that becomes HTML, which is a stored-XSS surface
+  (`<script>`, `onerror=`, `javascript:` URLs, malicious SVG). The rendered
+  HTML is passed through DOMPurify with a conservative allow-list before it ever
+  reaches the DOM. If syntax highlighting (step 5) emits raw HTML, it must be
+  produced *before* the final sanitize pass, or run through a highlighter that
+  only emits classed `<span>`s the sanitizer allows. The sanitization approach
+  is Open Question 5; *that* it happens is not negotiable.
+- **The ToC is generated from rendered headings, not from docz's own ToC
+  markers.** docz documents contain `<!--toc:start-->` / `<!--toc:end-->` marker
+  blocks that the CLI maintains. Rather than parse or trust those markers, the
+  reader builds the ToC by walking the rendered `<h1..h4>` nodes and assigning
+  slugged anchor ids, so the ToC is always consistent with what is displayed
+  (how to treat the literal marker block — strip it, ignore it, or render the
+  CLI-generated list — is Open Question 8).
+
+The **status badge** maps the frontmatter `status` value to a color. The set of
+valid statuses is per-type and comes from each repo's `.docz.yaml`
+(`TypeConfig.Statuses`), surfaced through docz-api's metadata, so the badge uses
+a small status→color convention with a neutral default for unknown values
+rather than a hardcoded enum.
+
+### Auth and session handling against docz-api
+
+Authentication is **pluggable** (Decision 6): the site supports GitHub (default,
+preferred), Okta, and Keycloak behind one OIDC/OAuth-shaped flow. The site never
+makes authorization decisions — docz-api enforces them — so the front-end auth
+job is narrow: get the user signed in, attach the session to API calls, and
+react to 401/403.
+
+Login flow (provider-agnostic; GitHub default):
+
+```
+/login            user picks a provider (or is sent straight to the default)
+   │  redirect to provider authorize URL (coordinated with docz-api)
+   ▼
+provider          user authenticates (GitHub OAuth / Okta or Keycloak OIDC)
+   │  redirect back with code
+   ▼
+/auth/callback    code is exchanged for a session
+   │  (where the token exchange happens — a site BFF vs. docz-api —
+   │   is Open Question 7; recommendation: docz-api owns it)
+   ▼
+session           session cookie (httpOnly, SameSite) issued by docz-api;
+                  site holds no long-lived token in JS
+```
+
+Session handling:
+
+- The session is carried as an **httpOnly cookie** set by docz-api (preferred)
+  so no access token sits in JavaScript-readable storage. The site sends
+  credentialed requests (`credentials: 'include'`) to docz-api.
+- On `401`, the site routes to `/login`, preserving the intended destination as
+  a return URL.
+- On `403`, the site shows a "you don't have access to this" state — this is
+  expected when a user follows a link to a repo/doc they cannot read.
+- Because authZ is server-side, the **repos list, type list, and search results
+  are already filtered** by docz-api to what the user may see. The site does not
+  filter content itself; it only renders what comes back. This means an
+  enumeration of repos is safe to show directly.
+
+### Loading, empty, and error states
+
+Every data-bound view defines four states; the data layer (TanStack Query)
+drives them:
+
+| State    | Trigger                          | UI                                                       |
+|----------|----------------------------------|----------------------------------------------------------|
+| Loading  | request in flight                | skeletons matching the target layout (list rows / reader) |
+| Empty    | request ok, zero results         | contextual empty message + a next action                 |
+| Error    | network / 5xx                    | inline error with a retry button; non-destructive        |
+| Auth     | 401 → `/login`; 403 → no-access  | redirect (401) or an access-denied panel (403)           |
+
+Examples: `/repos` with no onboarded repos shows "No repos yet — onboard one
+with the docz GitHub App"; a type page with no documents shows "No designs in
+acme/platform yet"; a search with zero hits shows the query and a "clear facets"
+action; a reader fetch error shows a retry without losing the breadcrumb.
+
+### Responsive layout
+
+The default layout is a persistent **left sidebar** (navigation/context) plus a
+**content area**; the reader adds a right-hand ToC rail on wide screens.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  docz-site            [ global search…                 ]   ◍ user ▾    │  top bar
+├───────────────┬────────────────────────────────────────┬─────────────┤
+│  SIDEBAR      │  CONTENT                                 │  ON THIS    │
+│               │                                          │  PAGE       │
+│  Repos        │  Repos / acme/platform / Designs /       │             │
+│   acme/...    │  DESIGN-0009                             │  • Overview │
+│   acme/web    │                                          │  • Goals    │
+│   org/infra   │  # DESIGN 0009: docz-site …  [Draft]     │  • Detailed │
+│               │                                          │    Design   │
+│  Types        │  Overview                                │  • API      │
+│   Designs     │  docz-site is the web front end that …   │  • Data     │
+│   RFCs        │                                          │    Model    │
+│   ADRs        │  Goals and Non-Goals                     │  • …        │
+│               │  …                                       │             │
+└───────────────┴────────────────────────────────────────┴─────────────┘
+```
+
+Breakpoints:
+
+- **Wide (≥1280px):** sidebar + content + ToC rail (three columns).
+- **Medium (≥768px):** sidebar + content; ToC collapses into an "On this page"
+  disclosure at the top of the reader.
+- **Small (<768px):** sidebar collapses behind a hamburger; single content
+  column; search moves into a full-screen overlay.
+
+The reader content column is width-capped (~72ch) for readability regardless of
+viewport.
+
+## API / Interface Changes
+
+docz-site is a new app and defines no public API of its own. This section
+describes (1) the docz-api endpoints it **consumes** and (2) the site's own
+client routes (already listed in the route map above). Endpoint paths are
+illustrative and must be reconciled with DESIGN-0008.
+
+**Consumed docz-api endpoints:**
+
+```
+GET  /api/v1/repos
+       → [{ owner, name, default_branch, doc_type_count, updated_at }]
+       Access-scoped: only repos the session may read.
+
+GET  /api/v1/repos/:owner/:repo
+       → { owner, name, default_branch, docs_dir, doc_types: [...] }
+
+GET  /api/v1/repos/:owner/:repo/types
+       → [{ name, plural_label, id_prefix, statuses, doc_count }]
+       Type-agnostic: whatever .docz.yaml enables, incl. custom types.
+
+GET  /api/v1/repos/:owner/:repo/types/:type/docs
+       → [{ doc_id, title, status, author, created, path, updated_at }]
+
+GET  /api/v1/repos/:owner/:repo/types/:type/docs/:docId
+       → { metadata: { id, title, status, author, created, ... },
+           raw_md: "…full markdown including frontmatter…",
+           git_sha }
+       The reader's source of truth: RAW markdown + parsed metadata.
+
+GET  /api/v1/search?q=&repo=&type=&status=&author=&page=
+       → { hits: [{ repo, doc_id, type, title, status, author,
+                     snippet }],
+           facets: { repo: {...}, type: {...},
+                     status: {...}, author: {...} },
+           total }
+       Backed by Meilisearch; results access-scoped server-side.
+
+GET  /api/v1/auth/session   → { user } | 401
+POST /api/v1/auth/logout    → 204
+     (login/callback redirect endpoints per the auth flow above)
+```
+
+All content/search endpoints are **access-scoped server-side**; the site
+receives only authorized data and surfaces 401/403 as described.
+
+**Example: fetch and render one document.** This is the thin-vertical-slice
+path — fetch raw markdown for `acme/platform / design / DESIGN-0009` and render
+it safely. Renderer-specific calls are illustrative.
+
+```ts
+import DOMPurify from "dompurify";
+import { renderMarkdown } from "./markdown"; // wraps markdown-it / remark
+
+async function loadDoc(owner: string, repo: string, type: string, docId: string) {
+  const res = await fetch(
+    `/api/v1/repos/${owner}/${repo}/types/${type}/docs/${docId}`,
+    { credentials: "include" },
+  );
+  if (res.status === 401) throw new AuthError();      // → /login
+  if (res.status === 403) throw new ForbiddenError(); // → access-denied panel
+  if (!res.ok) throw new ApiError(res.status);
+
+  const doc: Doc = await res.json();
+
+  // 1. render markdown body → HTML (renderer also highlights code)
+  const rawHtml = renderMarkdown(stripFrontmatter(doc.rawMd));
+
+  // 2. SANITIZE — mandatory: this is user content → HTML
+  const safeHtml = DOMPurify.sanitize(rawHtml, { USE_PROFILES: { html: true } });
+
+  // 3. build ToC from rendered headings (not docz's toc markers)
+  const toc = buildToc(safeHtml);
+
+  return { metadata: doc.metadata, html: safeHtml, toc };
+}
+```
+
+```tsx
+function DocReader({ owner, repo, type, docId }: DocReaderProps) {
+  const { data, status } = useQuery({
+    queryKey: ["doc", owner, repo, type, docId],
+    queryFn: () => loadDoc(owner, repo, type, docId),
+  });
+
+  if (status === "pending") return <ReaderSkeleton />;
+  if (status === "error")   return <ReaderError owner={owner} repo={repo} />;
+
+  return (
+    <article>
+      <Breadcrumbs owner={owner} repo={repo} type={type} docId={docId} />
+      <StatusBadge status={data.metadata.status} />
+      <TableOfContents toc={data.toc} />
+      {/* html is already sanitized by loadDoc */}
+      <div className="prose" dangerouslySetInnerHTML={{ __html: data.html }} />
+    </article>
+  );
+}
+```
+
+## Data Model
+
+The site is **essentially stateless** — a thin client with no database. The
+"data model" is (1) the TypeScript view-model shapes that mirror docz-api's JSON
+and (2) the client-side query cache.
+
+**View-model interfaces** (the contract the site renders against):
+
+```ts
+interface Repo {
+  owner: string;
+  name: string;            // `${owner}/${name}` is the repo key
+  defaultBranch: string;
+  docsDir: string;
+  docTypeCount: number;
+  updatedAt: string;       // ISO-8601
+}
+
+interface DocType {
+  name: string;            // canonical type name, e.g. "design" or "frameworks"
+  pluralLabel: string;     // display label, e.g. "Designs"
+  idPrefix: string;        // e.g. "DESIGN", "FW"
+  statuses: string[];      // valid statuses for this type (from .docz.yaml)
+  docCount: number;
+}
+
+interface DocSummary {     // a row in a type's document list
+  docId: string;           // stable frontmatter id, e.g. "DESIGN-0009"
+  title: string;
+  status: string;
+  author: string;
+  created: string;         // ISO-8601 date
+  path: string;            // repo-relative source path
+  updatedAt: string;
+}
+
+interface Doc {            // the full reader payload
+  metadata: {
+    id: string;
+    title: string;
+    status: string;
+    author: string;
+    created: string;
+    [k: string]: unknown;  // forward-compatible with extra frontmatter keys
+  };
+  rawMd: string;           // raw markdown incl. frontmatter; rendered client-side
+  gitSha: string;
+}
+
+interface SearchHit {
+  repo: string;            // `${owner}/${name}`
+  docId: string;
+  type: string;
+  title: string;
+  status: string;
+  author: string;
+  snippet: string;         // highlighted excerpt from Meilisearch
+}
+
+interface SearchResponse {
+  hits: SearchHit[];
+  facets: {
+    repo: Record<string, number>;
+    type: Record<string, number>;
+    status: Record<string, number>;
+    author: Record<string, number>;
+  };
+  total: number;
+}
+```
+
+`status` and `type` are typed as `string` (not a closed enum) because the type
+and status sets are **per-repo, driven by `.docz.yaml`** — the site must render
+whatever docz-api returns, including custom types and custom statuses.
+
+**Client-side caching.** The only persisted-ish state is the in-memory query
+cache (TanStack Query): keyed by route params (`["repos"]`,
+`["repo", owner, name]`, `["docs", owner, repo, type]`,
+`["doc", owner, repo, type, docId]`, `["search", params]`), with
+stale-while-revalidate so navigating back to a list is instant while a
+background refetch runs. Cache entries are dropped on logout. Rendered/sanitized
+HTML may be memoized per `docId` within a session to avoid re-parsing on
+re-mount; it is never written to durable storage. No localStorage of document
+content (it would duplicate access-scoped data outside docz-api's control); only
+UI preferences (theme, last provider) may be persisted.
+
+## Testing Strategy
+
+- **Component / unit (Vitest + Testing Library).** Breadcrumbs derive correctly
+  from route params; the status badge maps known statuses to colors and falls
+  back gracefully for unknown ones; facet selection updates the URL and
+  vice-versa; loading/empty/error/auth states render for each data-bound view;
+  the four-state matrix is covered per route.
+- **Markdown rendering + sanitization (the security-critical suite).** A
+  dedicated table of **XSS payloads** must be *neutralized* by the
+  render → sanitize pipeline: `<script>alert(1)</script>`,
+  `<img src=x onerror=alert(1)>`, `[x](javascript:alert(1))`,
+  `<a href="javascript:…">`, event-handler attributes, `<iframe>`/`<object>`,
+  and malicious inline SVG/MathML. Each test asserts the sanitized output
+  contains no executable vector. Companion tests assert *benign* markdown
+  (headings, tables, fenced code, links, images) survives intact and that ToC
+  generation produces stable slugged anchors. These tests gate CI.
+- **End-to-end (Playwright) against a mocked/fixture docz-api.** Drive the real
+  flows — `/repos` → repo → type → reader; faceted search; 401→`/login` and
+  403→access-denied — against recorded fixture responses (and a contract check
+  that fixtures match docz-api's documented schema). Cover the thin-vertical-
+  slice happy path first.
+- **Accessibility checks.** Automated axe scans in component and e2e tests;
+  keyboard navigation through sidebar, search, facets, and the in-page ToC;
+  visible focus states; correct landmark/heading structure in the reader;
+  color-contrast on status badges.
+
+## Migration / Rollout Plan
+
+This is a **greenfield repository** with no existing users to migrate; "rollout"
+means the build order, which follows Decision 8 (thin vertical slice first).
+
+1. **Slice 1 — render one repo's one type, no auth/search/nav.** Stand up the
+   SPA, a single hardcoded route to a document reader, and the full reader
+   pipeline (fetch raw md → render → **sanitize** → highlight → ToC → status
+   badge) against a **minimal docz-api** (or fixtures) serving one repo's one
+   type. This proves the end-to-end fetch→render→display loop and ships the
+   security-critical sanitization suite from day one.
+2. **Slice 2 — full navigation.** Add `/repos`, repo detail, type list, and
+   breadcrumbs; wire the route map and the loading/empty/error states.
+3. **Slice 3 — search.** Add `/search`, the facet sidebar, and the cross-repo
+   views (which are just faceted queries). Resolve the proxy-vs-scoped-key
+   question (Open Question 4).
+4. **Slice 4 — auth.** Add the pluggable login flow (GitHub default; Okta /
+   Keycloak), session handling, and 401/403 behavior, coordinated with
+   docz-api. Until this lands, the site runs against an unauthenticated or
+   single-tenant docz-api.
+5. **Slice 5 — polish.** Responsive refinements, accessibility hardening,
+   performance (code-split routes, prefetch on hover), and any SSR adoption if
+   Open Question 3 lands on SSR.
+
+Each slice is independently shippable; nothing in a later slice is required for
+an earlier one to be useful.
+
+## Open Questions
+
+Each question is numbered; option `a` is the recommendation, later letters are
+alternatives, and "Other" is free-form for review.
+
+### 1. Which front-end framework?
+
+- **a. (Recommended)** Vite + React SPA — no server runtime, fastest path to the
+  thin vertical slice, docz-api as the only backend.
+- b. Next.js (React + SSR) — SEO-able public docs, faster first paint, and a
+  natural home for a BFF token exchange.
+- c. SvelteKit — smaller bundles, built-in SSR, less boilerplate.
+- d. Other.
+
+### 2. Which markdown renderer library?
+
+- **a. (Recommended)** `markdown-it` + plugins (anchors, footnotes, highlight) —
+  framework-agnostic, mature, easy to feed into DOMPurify as an HTML string.
+- b. `react-markdown` / `remark` — renders to React nodes (no `dangerouslySet…`
+  for the common path), rich remark/rehype plugin ecosystem.
+- c. `marked` — smallest/fastest, fewer plugins.
+- d. Other.
+
+### 3. SSR or SPA?
+
+- **a. (Recommended)** SPA for the MVP — operationally simplest, defers a server
+  runtime; revisit once public/SEO docs are a requirement.
+- b. SSR from the start — better first paint, SEO, and a server seam for auth.
+- c. Static prerender + client hydration for public docs, SPA for private.
+- d. Other.
+
+### 4. How does the site integrate with Meilisearch search?
+
+- **a. (Recommended)** Proxy through a docz-api `/search` endpoint — the same
+  server-side access scoping filters search results, no Meilisearch key reaches
+  the browser, one backend.
+- b. Direct Meilisearch instant-search with a per-session **scoped tenant
+  token** issued by docz-api — lowest latency, native instant-search components,
+  at the cost of trusting browser-side filter constraints.
+- c. Hybrid: proxy for access-scoped queries, direct for public docs only.
+- d. Other.
+
+### 5. HTML sanitization approach?
+
+- **a. (Recommended)** DOMPurify with a conservative allow-list, run after
+  render and after highlighting — battle-tested, browser-native, configurable.
+- b. A `rehype-sanitize` step in a remark/rehype pipeline (pairs with Open
+  Question 2b) — sanitizes the AST before serialization.
+- c. Server-side sanitization in docz-api before it serves markdown/HTML — moves
+  the trust boundary off the client but conflicts with Decision 3 (client-side
+  render).
+- d. Other.
+
+### 6. Styling / design-system choice?
+
+- **a. (Recommended)** Tailwind CSS + a headless component set (e.g. Radix) plus
+  a `prose` typography preset for the reader — fast, consistent, accessible
+  primitives.
+- b. A batteries-included component library (MUI / Chakra / Mantine) — more
+  out-of-the-box, heavier and more opinionated.
+- c. Plain CSS modules / vanilla-extract — minimal deps, more hand-rolled UI.
+- d. Other.
+
+### 7. Where does the OIDC/OAuth token exchange happen?
+
+- **a. (Recommended)** docz-api owns the exchange and issues an httpOnly session
+  cookie — keeps tokens out of browser JS and centralizes auth with the access
+  control that already lives in docz-api.
+- b. A thin site BFF (requires SSR per Open Question 3b) performs the exchange
+  and brokers the docz-api session — keeps provider secrets at the site edge.
+- c. Public-client PKCE in the SPA with tokens in memory — no server seam, but
+  the browser holds tokens.
+- d. Other.
+
+### 8. How should docz's own ToC markers be handled?
+
+- **a. (Recommended)** Generate the ToC from rendered headings and **strip** the
+  `<!--toc:start-->…<!--toc:end-->` marker block from the displayed body — one
+  ToC, always consistent with what's shown.
+- b. Render the CLI-generated ToC list verbatim (trust the marker block) and
+  skip heading-walking.
+- c. Render the marker block *and* a generated rail, accepting possible
+  duplication.
+- d. Other.
+
+## References
+
+- INV-0005 — "docz-api and docz-site: centralized cross-repo docz registry and
+  viewer" (source investigation; locked Decisions 2, 3, 6, 8 honored here).
+- DESIGN-0008 — docz-api (the service docz-site consumes: GitHub App ingestion,
+  Postgres registry caching raw markdown + metadata, Meilisearch index, webhook
+  refresh, access-scoped/auth endpoints).
+- DESIGN-0007 — the docz shared parsing library (`pkg/…` extracted from
+  `internal/config` + `internal/document`) that docz-api depends on so the
+  registry never drifts from the CLI; consumed by docz-site transitively via
+  docz-api.
+- DESIGN-0006 — custom document type support (why the registry and the site must
+  be **type-agnostic**, driven by each repo's `.docz.yaml`).
+- Meilisearch — full-text search + faceting backing docz-api's `/search`.
+- markdown-it / react-markdown / remark — candidate client-side markdown
+  renderers (Open Question 2).
+- DOMPurify — HTML sanitization for the reader's XSS surface (Open Question 5).
+- TanStack Query — client-side request cache / data layer.
+- Playwright — end-to-end testing against a mocked/fixture docz-api.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -38,4 +38,7 @@ docz create design "Your Design Title"
 | DESIGN-0004 | Runner Pattern and DocType Registry | Approved | 2026-05-27 | Donald Gifford | [0004-runner-pattern-and-doctype-registry.md](0004-runner-pattern-and-doctype-registry.md) |
 | DESIGN-0005 | Status Set CLI Primitive | Implemented | 2026-05-30 | Donald Gifford | [0005-status-set-cli-primitive.md](0005-status-set-cli-primitive.md) |
 | DESIGN-0006 | Custom Document Type Support | Implemented | 2026-06-17 | Donald Gifford | [0006-custom-document-type-support.md](0006-custom-document-type-support.md) |
+| DESIGN-0007 | docz changes to support docz-api and docz-site | Draft | 2026-06-23 | Donald Gifford | [0007-docz-changes-to-support-docz-api-and-docz-site.md](0007-docz-changes-to-support-docz-api-and-docz-site.md) |
+| DESIGN-0008 | docz-api: cross-repo docz registry and ingestion service | Draft | 2026-06-23 | Donald Gifford | [0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md](0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md) |
+| DESIGN-0009 | docz-site: cross-repo docz viewer and search UI | Draft | 2026-06-23 | Donald Gifford | [0009-docz-site-cross-repo-docz-viewer-and-search-ui.md](0009-docz-site-cross-repo-docz-viewer-and-search-ui.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md
+++ b/docs/investigation/0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md
@@ -1,7 +1,7 @@
 ---
 id: INV-0005
 title: "docz-api and docz-site: centralized cross-repo docz registry and viewer"
-status: Open
+status: Concluded
 author: Donald Gifford
 created: 2026-06-23
 ---
@@ -9,7 +9,7 @@ created: 2026-06-23
 
 # INV 0005: docz-api and docz-site: centralized cross-repo docz registry and viewer
 
-**Status:** Open
+**Status:** Concluded
 **Author:** Donald Gifford
 **Date:** 2026-06-23
 
@@ -37,6 +37,7 @@ created: 2026-06-23
   - [6. What is the visibility / access model?](#6-what-is-the-visibility--access-model)
   - [7. How does the API obtain the doc list without re-implementing docz?](#7-how-does-the-api-obtain-the-doc-list-without-re-implementing-docz)
   - [8. Scope of the first deliverable?](#8-scope-of-the-first-deliverable)
+- [Decisions](#decisions)
 - [References](#references)
 <!--toc:end-->
 
@@ -111,14 +112,15 @@ reached and how a follow-on design would be de-risked:
 
 Proposed stack (assumed, to be confirmed in design):
 
-| Component        | Proposed choice                                            |
-|------------------|------------------------------------------------------------|
-| Onboarding/auth  | GitHub App (installation tokens, webhooks)                 |
-| API service      | Go (reuses docz's own parsing packages)                    |
-| Registry store   | PostgreSQL                                                 |
-| Search           | Meilisearch (full-text + faceting)                         |
-| Markdown render  | mdp renderer (parity with docz preview) → cached HTML      |
-| Front end        | docz-site (repos → types → docs nav + search + reader)     |
+| Component            | Proposed choice                                        |
+|----------------------|--------------------------------------------------------|
+| Ingestion/onboarding | GitHub App (installation tokens, webhooks)             |
+| Site user auth       | Pluggable OIDC: GitHub (default), Okta, Keycloak       |
+| API service          | Go (reuses docz's own parsing packages)                |
+| Registry store       | PostgreSQL (caches raw markdown + metadata at ingest)  |
+| Search               | Meilisearch (full-text + faceting)                     |
+| Markdown render      | JS renderer in docz-site (e.g. markdown-it)            |
+| Front end            | docz-site (repos → types → docs nav + search + reader) |
 
 ## Findings
 
@@ -162,9 +164,10 @@ docz-api enumerates installed repos and ingests any that contain a `.docz.yaml`
 at the repo root.
 
 **Ingestion (docz-api).** Per repo: fetch `.docz.yaml` + the doc files, parse,
-upsert into Postgres, index into Meilisearch, render+cache HTML. Fetching can use
-the GitHub Git Trees/Contents API (no checkout) for small doc sets, or a shallow
-clone for large ones.
+upsert into Postgres (caching the raw markdown + metadata), and index into
+Meilisearch. Markdown→HTML is **not** done here — docz-site renders client-side
+(Decision 3). Fetching can use the GitHub Git Trees/Contents API (no checkout)
+for small doc sets, or a shallow clone for large ones.
 
 **Data model (Postgres), sketch:**
 
@@ -172,14 +175,15 @@ clone for large ones.
   config_snapshot jsonb, last_synced_sha, updated_at)`
 - `doc_types(id, repo_id, name, dir, id_prefix, plural_label, statuses jsonb)`
 - `documents(id, repo_id, type, doc_id, title, status, author, created_at,
-  path, git_sha, content_hash, raw_md, rendered_html, updated_at)` — unique on
-  `(repo_id, doc_id)`.
+  path, git_sha, content_hash, raw_md, updated_at)` — unique on
+  `(repo_id, doc_id)`. `raw_md` is the cached markdown; docz-site renders it to
+  HTML client-side (Decision 3), so no `rendered_html` column is stored.
 
 **Refresh via webhooks.** A `push` to the default branch touching `docs_dir`
 (or `.docz.yaml`) triggers a diff-based re-ingest of only the changed files;
 `.docz.yaml` changes re-sync the type set. A `release`/tag can optionally
-snapshot a version. Events are debounced. `content_hash` gates re-rendering so
-unchanged docs are not re-processed.
+snapshot a version. Events are debounced. `content_hash` gates re-ingest so
+unchanged docs are not re-processed or re-indexed.
 
 **Search (Meilisearch).** One index of documents with searchable `title`/`body`
 and facets on `repo`, `type`, `status`, `author`. Drives both global search and
@@ -212,11 +216,32 @@ a real, additive docz roadmap item, not a blocker for a prototype.
 ### Observation 5 — the hard part is visibility/auth, and it is not docz-specific
 
 The one piece that is *not* simplified: a viewer aggregating private-repo content
-must enforce that a site user only sees docs from repos they can access on
-GitHub. This is exactly rfc-api's hardest problem. Options range from "org-
-internal, trust everyone in the org" (simplest, viable for an MVP) to "OAuth the
-site user and check their GitHub repo access per request" (correct, more work).
-This must be decided early because it shapes the API and the site session model.
+must enforce that a site user only sees docs they are allowed to see. This is
+exactly rfc-api's hardest problem, and it splits into two layers:
+
+- **Authentication (who is this user?)** is **pluggable** (Decision 6). The site
+  supports three providers behind one OIDC-shaped abstraction: **GitHub**
+  (default and preferred — the GitHub App already in play for ingestion doubles
+  as the OAuth identity provider), **Okta**, and **Keycloak**. GitHub uses
+  OAuth; Okta and Keycloak use standard OIDC. A single provider interface
+  (`issuer`, `client_id/secret`, scopes/claims) keeps the three configurable
+  rather than forked.
+- **Authorization (what may they see?)** is where the providers diverge and must
+  be designed explicitly:
+  - *GitHub provider* — mirror GitHub access: a user sees a repo's docs only if
+    their token can read that repo (checked/cached per session). This is the
+    natural, tightest mapping.
+  - *Okta / Keycloak providers* — there is no GitHub repo-permission signal, so
+    authorization comes from **OIDC group/role claims** mapped to repos or repo
+    groups in docz-api config (e.g. `group:platform → repos[…]`), or a coarser
+    "any authenticated org member sees all onboarded repos" for an internal
+    deployment.
+
+Note the **asymmetry**: ingestion is *always* via the GitHub App (that is how
+docz-api reads repo content), independent of how site *users* authenticate. So
+"auth provider" is strictly about the human reading the site, not about how the
+service pulls content. This must be decided early because it shapes the API,
+the session model, and the config surface.
 
 ### Observation 6 — why docz-site is not "just MkDocs per repo"
 
@@ -233,27 +258,36 @@ location (`.docz.yaml`), structure (typed dirs), and metadata (frontmatter), the
 ingestion side of docz-api is largely mechanical, and the rfc-api/rfc-site
 architecture (GitHub App → Postgres registry → Meilisearch → viewer, refreshed by
 webhooks) maps cleanly onto it. The dominant remaining complexity is the
-visibility/auth model, which is inherent to any cross-repo viewer of private
-content and not unique to docz. A clean implementation also motivates a small,
-additive docz change: exposing the existing config/document parsing as a shared
-library (or a JSON manifest export) so the API and CLI never diverge.
+visibility/auth model — now scoped to a **pluggable provider abstraction**
+(GitHub by default, plus Okta and Keycloak via OIDC; Decision 6) — which is
+inherent to any cross-repo viewer of private content and not unique to docz. A
+clean implementation also motivates a small, additive docz change: exposing the
+existing config/document parsing as a shared library so the API and CLI never
+diverge (Decision 7).
 
 ## Recommendation
+
+The open questions are resolved (see [Decisions](#decisions)). Next steps:
 
 1. **Proceed to a DESIGN** for docz-api (the service: GitHub App, ingestion,
    data model, webhook refresh, search) and either a combined or sibling DESIGN
    for docz-site (the viewer: nav, search, reader). One service design with the
    site as a section is likely enough to start.
-2. **Resolve the Open Questions below** during that design — especially the
-   visibility/auth model (Q6), which gates almost everything else.
-3. **Scope the docz prerequisite** (Observation 4 / Q7–Q8): decide whether to
-   extract a shared parsing package or add a `docz export --json` before, or in
-   parallel with, the service prototype.
-4. **Build a thin vertical slice first:** one repo onboarded by hand → ingest →
-   one type rendered in a bare docz-site, deferring auth and webhooks, to prove
-   the fetch→parse→render→serve loop before investing in the full pipeline.
+2. **Design the pluggable auth layer first** (Decision 6) — the GitHub /
+   Okta / Keycloak provider abstraction and, critically, the per-provider
+   *authorization* mapping (GitHub repo access vs. OIDC group claims). It gates
+   the API and the session model.
+3. **Scope the docz prerequisite** (Observation 4 / Decisions 7): extract a
+   shared `pkg/…` parsing library from `internal/config` + `internal/document`
+   so docz-api and the CLI never diverge.
+4. **Build a thin vertical slice first** (Decision 8): one repo onboarded by
+   hand → ingest → one type rendered in a bare docz-site, deferring auth and
+   webhooks, to prove the fetch→parse→render→serve loop before the full pipeline.
 
 ## Open Questions
+
+> **Resolved 2026-06-23** — see the [Decisions](#decisions) table below for the
+> chosen option per question. The menu of alternatives is kept for the record.
 
 Each question is numbered; option `a` is the recommendation, later letters are
 alternatives, and "other" is free-form for review.
@@ -324,6 +358,22 @@ alternatives, and "other" is free-form for review.
 - c. Site/UX prototype first against mocked data.
 - d. Other.
 
+## Decisions
+
+Resolved by user review on 2026-06-23. Recommendations accepted except
+Decisions 3 and 6, which were adjusted per reviewer guidance.
+
+| # | Topic | Choice | Rationale |
+|---|-------|--------|-----------|
+| 1 | Repo content fetch | (a) GitHub Git Trees / Contents API | No checkout; simplest ops for typical doc-set sizes |
+| 2 | Cache point | (a) Cache at ingest | Cache the raw markdown + metadata in Postgres at ingest (HTML itself is rendered client-side per Decision 3) |
+| 3 | Markdown renderer | **(c) JS renderer in docz-site** | mdp is intentionally small for single-user neovim/terminal use and isn't a fit for a server-side multi-tenant renderer; render in the site instead |
+| 4 | "Version" semantics | (a) Default-branch HEAD as current version | Simplest correct MVP; store `git_sha` per doc |
+| 5 | Branch scope | (a) Default branch only | Avoids preview/PR-branch noise |
+| 6 | Auth model | **(a) GitHub default + pluggable OIDC** | GitHub App OAuth is default/preferred; a generic OIDC provider abstraction must also support Okta and Keycloak. All three are required; authorization mapping differs per provider (see Observation 5) |
+| 7 | Doc-list source | (a) Shared `pkg/…` library from docz | Single source of truth; API and CLI never drift |
+| 8 | First deliverable | (a) Thin vertical slice | Prove fetch→parse→render→serve on one repo before the full pipeline |
+
 ## References
 
 - docz `.docz.yaml` schema and type model — `internal/config`
@@ -333,4 +383,6 @@ alternatives, and "other" is free-form for review.
   type-agnostic, driven by each repo's config)
 - docz per-repo wiki (MkDocs/TechDocs) — the per-repo counterpart to docz-site
 - mdp markdown renderer — [[0004-v1-release-plan-tui-markdown-preview-and-cli-parity]]
+  (considered for server-side rendering but rejected in Decision 3 — it is
+  intentionally scoped to single-user neovim/terminal use)
 - Prior art: rfc-api / rfc-site (the general system docz-api simplifies)

--- a/docs/investigation/0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md
+++ b/docs/investigation/0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md
@@ -1,0 +1,336 @@
+---
+id: INV-0005
+title: "docz-api and docz-site: centralized cross-repo docz registry and viewer"
+status: Open
+author: Donald Gifford
+created: 2026-06-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0005: docz-api and docz-site: centralized cross-repo docz registry and viewer
+
+**Status:** Open
+**Author:** Donald Gifford
+**Date:** 2026-06-23
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [Observation 1 — docz hands the ingester a manifest, not a haystack](#observation-1--docz-hands-the-ingester-a-manifest-not-a-haystack)
+  - [Observation 2 — the rfc-api/rfc-site model maps cleanly, minus the hard parsing](#observation-2--the-rfc-apirfc-site-model-maps-cleanly-minus-the-hard-parsing)
+  - [Observation 3 — proposed architecture](#observation-3--proposed-architecture)
+  - [Observation 4 — the docz-side enabler: don't re-implement the parser](#observation-4--the-docz-side-enabler-dont-re-implement-the-parser)
+  - [Observation 5 — the hard part is visibility/auth, and it is not docz-specific](#observation-5--the-hard-part-is-visibilityauth-and-it-is-not-docz-specific)
+  - [Observation 6 — why docz-site is not "just MkDocs per repo"](#observation-6--why-docz-site-is-not-just-mkdocs-per-repo)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [Open Questions](#open-questions)
+  - [1. How does docz-api fetch repo content?](#1-how-does-docz-api-fetch-repo-content)
+  - [2. Where is markdown rendered to HTML?](#2-where-is-markdown-rendered-to-html)
+  - [3. Which renderer?](#3-which-renderer)
+  - [4. What does "version" mean for a doc?](#4-what-does-version-mean-for-a-doc)
+  - [5. Which branch(es) are ingested?](#5-which-branches-are-ingested)
+  - [6. What is the visibility / access model?](#6-what-is-the-visibility--access-model)
+  - [7. How does the API obtain the doc list without re-implementing docz?](#7-how-does-the-api-obtain-the-doc-list-without-re-implementing-docz)
+  - [8. Scope of the first deliverable?](#8-scope-of-the-first-deliverable)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+Can we build a small companion service — **docz-api** — that uses a GitHub App
+to onboard repositories already using docz, ingests each repo's `.docz.yaml` to
+build a registry of documents (mapped to repos and doc types), caches their
+rendered content, and refreshes via webhooks on push/merge/release — paired with
+a **docz-site** front end that lets a team browse, search, and read *all* their
+docz documents from a single web URL?
+
+And specifically: does docz's existing structure (`.docz.yaml`, standardized
+directory layout, typed YAML frontmatter, stable IDs) make this materially
+*simpler* than a general system like rfc-api / rfc-site?
+
+## Hypothesis
+
+**Yes — and meaningfully simpler than rfc-api.** rfc-api spends most of its
+complexity on *discovery* and *normalization*: figuring out where docs live in
+an arbitrary repo and coercing inconsistent metadata into a common shape. docz
+already solves both problems at the source:
+
+- `.docz.yaml` is a **manifest** — it declares `docs_dir` and every type's
+  `dir`, `id_prefix`, `statuses`, and `plural_label`. The API never has to guess
+  where docs are.
+- Every document carries **typed, guaranteed frontmatter** (`id`, `title`,
+  `status`, `author`, `created`), so registry rows and search fields map almost
+  one-to-one with no heuristic parsing.
+- IDs are **stable and namespaced** (`RFC-0001`, `FW-0003`), giving a natural
+  per-repo primary key and a clean cross-repo identity (`<repo>/<id>`).
+
+So docz-api is mostly "fetch → parse known structure → upsert → index → render
+cache," with webhooks driving incremental refresh. The genuinely hard part is
+not docz-specific — it is the same problem rfc-api has: **mapping who-can-see-
+what** from GitHub repo access to site access.
+
+## Context
+
+docz today produces beautifully structured docs *per repo*, and the `wiki`
+command can render a single repo's docs as MkDocs/TechDocs. What's missing is a
+**cross-repo** view: a team with docz in 15 repos has 15 separate doc trees and
+no single place to search "all our ADRs" or "every Draft design across the org."
+This investigation validates whether a thin aggregation service modeled on
+rfc-api / rfc-site (Postgres registry + Meilisearch + a viewer) is the right
+shape, and what — if anything — docz itself must expose to support it cleanly.
+
+**Triggered by:** the desire for one URL across all docz repos; relationship to
+the existing per-repo `wiki` (MkDocs/TechDocs) integration and the mdp renderer
+explored in [[0004-v1-release-plan-tui-markdown-preview-and-cli-parity]].
+
+## Approach
+
+This is a **desk / feasibility investigation** (architecture validation), not an
+empirical spike with running code. The steps below are how the conclusion was
+reached and how a follow-on design would be de-risked:
+
+1. Enumerate exactly what docz already standardizes that an ingester can rely on
+   (`.docz.yaml` schema, directory layout, frontmatter fields, index markers).
+2. Map the rfc-api / rfc-site component model onto docz and identify which parts
+   collapse or disappear because docz removes discovery/normalization.
+3. Sketch the data model (Postgres), the ingestion + webhook refresh flow, the
+   search index (Meilisearch), the render/cache strategy, and the docz-site
+   navigation (repos → types → documents).
+4. Identify the docz-side prerequisite: how the API gets a doc list without
+   re-implementing docz's parser (shared library vs. JSON export vs. shelling
+   out).
+5. Surface the unavoidable risks (visibility/auth, versioning semantics, fetch
+   strategy) as Open Questions for the design phase.
+
+## Environment
+
+Proposed stack (assumed, to be confirmed in design):
+
+| Component        | Proposed choice                                            |
+|------------------|------------------------------------------------------------|
+| Onboarding/auth  | GitHub App (installation tokens, webhooks)                 |
+| API service      | Go (reuses docz's own parsing packages)                    |
+| Registry store   | PostgreSQL                                                 |
+| Search           | Meilisearch (full-text + faceting)                         |
+| Markdown render  | mdp renderer (parity with docz preview) → cached HTML      |
+| Front end        | docz-site (repos → types → docs nav + search + reader)     |
+
+## Findings
+
+### Observation 1 — docz hands the ingester a manifest, not a haystack
+
+The single biggest simplification: `.docz.yaml` *is* the per-repo manifest. To
+ingest a repo, docz-api reads one file and learns:
+
+- `docs_dir` — the root to scan.
+- For each type: `dir`, `id_prefix`, `id_width`, `statuses`, `plural_label`,
+  and (since IMPL-0012) `aliases`. This includes **custom types**, so the
+  registry must be type-agnostic and driven entirely by the repo's config —
+  never a hardcoded list of the six built-ins.
+
+Then for each enabled type it scans `<docs_dir>/<dir>/*.md` and parses
+frontmatter — the exact job docz's own `internal/document.ScanDocuments`
+already does. The output (`id`, `title`, `status`, `author`, `created`, path)
+maps directly onto a registry row and a search document. No discovery, no
+metadata coercion. This is the work rfc-api cannot avoid and docz-api gets for
+free.
+
+### Observation 2 — the rfc-api/rfc-site model maps cleanly, minus the hard parsing
+
+| rfc-api / rfc-site concern | docz-api equivalent | Notes |
+|---|---|---|
+| Discover where docs live | Read `.docz.yaml` | Eliminated as a problem |
+| Normalize metadata | Read typed frontmatter | Eliminated; schema is fixed |
+| Registry store | Postgres | Same |
+| Full-text search | Meilisearch | Same |
+| Render markdown | mdp → cached HTML | Reuse docz's renderer |
+| Onboarding | GitHub App install | Simpler: one app, opt-in repos |
+| Refresh on change | Webhooks (push/release) | Same pattern |
+| **Access control** | **Map GH repo access → site** | **Unchanged; the hard part** |
+
+### Observation 3 — proposed architecture
+
+**Onboarding.** A GitHub App is installed on selected repos/orgs. Required
+permissions are minimal: `contents: read`, `metadata: read`; webhook events:
+`installation` / `installation_repositories`, `push`, and `release`. On install,
+docz-api enumerates installed repos and ingests any that contain a `.docz.yaml`
+at the repo root.
+
+**Ingestion (docz-api).** Per repo: fetch `.docz.yaml` + the doc files, parse,
+upsert into Postgres, index into Meilisearch, render+cache HTML. Fetching can use
+the GitHub Git Trees/Contents API (no checkout) for small doc sets, or a shallow
+clone for large ones.
+
+**Data model (Postgres), sketch:**
+
+- `repos(id, installation_id, owner, name, default_branch, docs_dir,
+  config_snapshot jsonb, last_synced_sha, updated_at)`
+- `doc_types(id, repo_id, name, dir, id_prefix, plural_label, statuses jsonb)`
+- `documents(id, repo_id, type, doc_id, title, status, author, created_at,
+  path, git_sha, content_hash, raw_md, rendered_html, updated_at)` — unique on
+  `(repo_id, doc_id)`.
+
+**Refresh via webhooks.** A `push` to the default branch touching `docs_dir`
+(or `.docz.yaml`) triggers a diff-based re-ingest of only the changed files;
+`.docz.yaml` changes re-sync the type set. A `release`/tag can optionally
+snapshot a version. Events are debounced. `content_hash` gates re-rendering so
+unchanged docs are not re-processed.
+
+**Search (Meilisearch).** One index of documents with searchable `title`/`body`
+and facets on `repo`, `type`, `status`, `author`. Drives both global search and
+filtered views ("all Approved designs across repos").
+
+**docz-site.** Navigation mirrors the mental model the request describes:
+**repos list → a repo → its doc types → a document**, plus a global search box
+and a rendered reader (HTML + ToC + a status badge from frontmatter). Cross-repo
+views (by type or status) fall out of the Meilisearch facets for free.
+
+### Observation 4 — the docz-side enabler: don't re-implement the parser
+
+docz-api should not re-implement frontmatter/config parsing — that would drift
+from the CLI. Three options, in order of preference:
+
+1. **Extract a shared Go module.** Promote the relevant pieces of
+   `internal/config` (Load/Validate, type resolution) and `internal/document`
+   (`ScanDocuments`, `LoadFrontmatter`) into a reusable `pkg/…` surface that both
+   the docz CLI and docz-api import. One source of truth for "what docz docs
+   exist in this tree."
+2. **Machine-readable export.** docz already has `docz list --format json`;
+   a small `docz export --json` (whole-repo manifest: config + all types + all
+   docs) would let the API consume docz's own output if a checkout is available.
+3. **Shell out** to the docz binary — simplest but couples deployment to having
+   the CLI installed and a checkout present.
+
+Option 1 is the cleanest and turns docz-api into a true peer of the CLI. This is
+a real, additive docz roadmap item, not a blocker for a prototype.
+
+### Observation 5 — the hard part is visibility/auth, and it is not docz-specific
+
+The one piece that is *not* simplified: a viewer aggregating private-repo content
+must enforce that a site user only sees docs from repos they can access on
+GitHub. This is exactly rfc-api's hardest problem. Options range from "org-
+internal, trust everyone in the org" (simplest, viable for an MVP) to "OAuth the
+site user and check their GitHub repo access per request" (correct, more work).
+This must be decided early because it shapes the API and the site session model.
+
+### Observation 6 — why docz-site is not "just MkDocs per repo"
+
+docz's existing `wiki` integration renders **one repo** as MkDocs/TechDocs.
+docz-site is deliberately different: it is **cross-repo aggregation + unified
+search + a single URL**. The two are complementary — per-repo TechDocs for deep
+single-project browsing, docz-site for the org-wide index. Worth stating in the
+design so the two features don't appear to overlap.
+
+## Conclusion
+
+**Answer: Yes — feasible, and simpler than rfc-api.** Because docz standardizes
+location (`.docz.yaml`), structure (typed dirs), and metadata (frontmatter), the
+ingestion side of docz-api is largely mechanical, and the rfc-api/rfc-site
+architecture (GitHub App → Postgres registry → Meilisearch → viewer, refreshed by
+webhooks) maps cleanly onto it. The dominant remaining complexity is the
+visibility/auth model, which is inherent to any cross-repo viewer of private
+content and not unique to docz. A clean implementation also motivates a small,
+additive docz change: exposing the existing config/document parsing as a shared
+library (or a JSON manifest export) so the API and CLI never diverge.
+
+## Recommendation
+
+1. **Proceed to a DESIGN** for docz-api (the service: GitHub App, ingestion,
+   data model, webhook refresh, search) and either a combined or sibling DESIGN
+   for docz-site (the viewer: nav, search, reader). One service design with the
+   site as a section is likely enough to start.
+2. **Resolve the Open Questions below** during that design — especially the
+   visibility/auth model (Q6), which gates almost everything else.
+3. **Scope the docz prerequisite** (Observation 4 / Q7–Q8): decide whether to
+   extract a shared parsing package or add a `docz export --json` before, or in
+   parallel with, the service prototype.
+4. **Build a thin vertical slice first:** one repo onboarded by hand → ingest →
+   one type rendered in a bare docz-site, deferring auth and webhooks, to prove
+   the fetch→parse→render→serve loop before investing in the full pipeline.
+
+## Open Questions
+
+Each question is numbered; option `a` is the recommendation, later letters are
+alternatives, and "other" is free-form for review.
+
+### 1. How does docz-api fetch repo content?
+
+- **a. (Recommended)** GitHub Git Trees / Contents API — no checkout, ideal for
+  small doc sets and simple ops.
+- b. Shallow `git clone` per refresh — better for large doc trees, heavier ops.
+- c. Hybrid: Contents API by default, clone above a size threshold.
+- d. Other.
+
+### 2. Where is markdown rendered to HTML?
+
+- **a. (Recommended)** Render at ingest time and cache `rendered_html` in
+  Postgres; invalidate on `content_hash` change.
+- b. Store raw markdown only; render in docz-site at request time.
+- c. Render client-side in the browser.
+- d. Other.
+
+### 3. Which renderer?
+
+- **a. (Recommended)** Reuse docz's mdp-based renderer for visual parity with the
+  CLI preview.
+- b. A server-side Go renderer in the API (e.g. goldmark) independent of mdp.
+- c. A JS renderer in docz-site.
+- d. Other.
+
+### 4. What does "version" mean for a doc?
+
+- **a. (Recommended)** Track the default-branch HEAD as the single current
+  version (MVP); store `git_sha` per doc.
+- b. Snapshot versions on git tags / GitHub releases.
+- c. Keep full per-doc history.
+- d. Other.
+
+### 5. Which branch(es) are ingested?
+
+- **a. (Recommended)** Default branch only.
+- b. Configurable per repo.
+- c. All branches (preview/PR builds).
+- d. Other.
+
+### 6. What is the visibility / access model?
+
+- **a. (Recommended)** Mirror GitHub repo access: GitHub App for ingestion +
+  user OAuth on the site, checking the viewer's repo access. Correct, and the
+  main complexity.
+- b. Org-internal single-tenant: trust any authenticated org member (simplest
+  MVP).
+- c. Public read-only (open-source docs only).
+- d. Other.
+
+### 7. How does the API obtain the doc list without re-implementing docz?
+
+- **a. (Recommended)** Extract docz's `internal/config` + `internal/document`
+  scanning into a shared `pkg/…` library imported by both CLI and API.
+- b. Add a `docz export --json` whole-repo manifest the API consumes (requires a
+  checkout / the binary).
+- c. Re-implement frontmatter + config parsing in the API (risks drift).
+- d. Other.
+
+### 8. Scope of the first deliverable?
+
+- **a. (Recommended)** A thin vertical slice: one hand-onboarded repo →
+  ingest → render one type in a minimal docz-site, no auth/webhooks yet.
+- b. Full ingestion pipeline + webhooks first, site second.
+- c. Site/UX prototype first against mocked data.
+- d. Other.
+
+## References
+
+- docz `.docz.yaml` schema and type model — `internal/config`
+- docz document scanning / frontmatter — `internal/document`
+  (`ScanDocuments`, `LoadFrontmatter`)
+- docz custom document types — DESIGN-0006 / IMPL-0012 (registry must be
+  type-agnostic, driven by each repo's config)
+- docz per-repo wiki (MkDocs/TechDocs) — the per-repo counterpart to docz-site
+- mdp markdown renderer — [[0004-v1-release-plan-tui-markdown-preview-and-cli-parity]]
+- Prior art: rfc-api / rfc-site (the general system docz-api simplifies)

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -17,7 +17,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0002 | Architectural Review and Cleanup Opportunities | Concluded | 2026-05-15 | Donald Gifford | [0002-architectural-review-and-cleanup-opportunities.md](0002-architectural-review-and-cleanup-opportunities.md) |
 | INV-0003 | Init and Update Should Respect Config-Listed Types Only | Concluded | 2026-05-20 | Donald Gifford | [0003-init-and-update-should-respect-config-listed-types-only.md](0003-init-and-update-should-respect-config-listed-types-only.md) |
 | INV-0004 | v1 Release Plan: TUI, Markdown Preview, and CLI Parity | Open | 2026-05-22 | Donald Gifford | [0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md](0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md) |
-| INV-0005 | docz-api and docz-site: centralized cross-repo docz registry and viewer | Open | 2026-06-23 | Donald Gifford | [0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md](0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md) |
+| INV-0005 | docz-api and docz-site: centralized cross-repo docz registry and viewer | Concluded | 2026-06-23 | Donald Gifford | [0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md](0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -17,6 +17,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0002 | Architectural Review and Cleanup Opportunities | Concluded | 2026-05-15 | Donald Gifford | [0002-architectural-review-and-cleanup-opportunities.md](0002-architectural-review-and-cleanup-opportunities.md) |
 | INV-0003 | Init and Update Should Respect Config-Listed Types Only | Concluded | 2026-05-20 | Donald Gifford | [0003-init-and-update-should-respect-config-listed-types-only.md](0003-init-and-update-should-respect-config-listed-types-only.md) |
 | INV-0004 | v1 Release Plan: TUI, Markdown Preview, and CLI Parity | Open | 2026-05-22 | Donald Gifford | [0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md](0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md) |
+| INV-0005 | docz-api and docz-site: centralized cross-repo docz registry and viewer | Open | 2026-06-23 | Donald Gifford | [0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md](0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
         - 'DESIGN-0003: Table of Contents Generation': design/0003-table-of-contents-generation.md
         - 'DESIGN-0004: Runner Pattern and DocType Registry': design/0004-runner-pattern-and-doctype-registry.md
         - 'DESIGN-0005: Status Set CLI Primitive': design/0005-status-set-cli-primitive.md
+        - 'DESIGN-0006: Custom Document Type Support': design/0006-custom-document-type-support.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: docz CLI Implementation': impl/0001-docz-cli-implementation.md
@@ -21,12 +22,14 @@ nav:
         - 'IMPL-0008: Move Stranded Business Logic Into Internal Packages': impl/0008-move-stranded-business-logic-into-internal-packages.md
         - 'IMPL-0009: Runner Pattern and DocType Registry Refactor': impl/0009-runner-pattern-and-doctype-registry-refactor.md
         - 'IMPL-0011: Status Set CLI Primitive': impl/0011-status-set-cli-primitive.md
+        - 'IMPL-0012: Custom Document Type Support': impl/0012-custom-document-type-support.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Wiki Init Template and Init Enabled Fix': investigation/0001-wiki-init-template-and-init-enabled-fix.md
         - 'INV-0002: Architectural Review and Cleanup Opportunities': investigation/0002-architectural-review-and-cleanup-opportunities.md
         - 'INV-0003: Init and Update Should Respect Config-Listed Types Only': investigation/0003-init-and-update-should-respect-config-listed-types-only.md
         - 'INV-0004: v1 Release Plan: TUI, Markdown Preview, and CLI Parity': investigation/0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md
+        - 'INV-0005: docz-api and docz-site: centralized cross-repo docz registry and viewer': investigation/0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,9 @@ nav:
         - 'DESIGN-0004: Runner Pattern and DocType Registry': design/0004-runner-pattern-and-doctype-registry.md
         - 'DESIGN-0005: Status Set CLI Primitive': design/0005-status-set-cli-primitive.md
         - 'DESIGN-0006: Custom Document Type Support': design/0006-custom-document-type-support.md
+        - 'DESIGN-0007: docz changes to support docz-api and docz-site': design/0007-docz-changes-to-support-docz-api-and-docz-site.md
+        - 'DESIGN-0008: docz-api: cross-repo docz registry and ingestion service': design/0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md
+        - 'DESIGN-0009: docz-site: cross-repo docz viewer and search UI': design/0009-docz-site-cross-repo-docz-viewer-and-search-ui.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: docz CLI Implementation': impl/0001-docz-cli-implementation.md


### PR DESCRIPTION
Research + design docs for a planned cross-repo docz aggregation service.
Docs-only — no code, no release (`dont-release`).

## Contents

- **INV-0005** (Concluded) — feasibility investigation for **docz-api** (a
  GitHub App that ingests onboarded repos' `.docz.yaml` into a Postgres
  registry + Meilisearch, refreshed via webhooks) and **docz-site** (a
  single-URL cross-repo viewer). Concludes it's feasible and simpler than
  rfc-api because docz already standardizes location/structure/metadata.
  8 open questions resolved into a Decisions table.
- **DESIGN-0007** (this repo) — promote `internal/config` +
  `internal/document` into a public `pkg/doczcore` library so docz-api
  reuses docz's parser without drift; optional `docz export --json`.
- **DESIGN-0008** (seeds a new `docz-api` repo) — GitHub App ingestion,
  Git Trees fetch, raw-markdown caching, Postgres + Meilisearch, webhook
  refresh, pluggable GitHub/Okta/Keycloak auth. Full SQL schema + JSON API.
- **DESIGN-0009** (seeds a new `docz-site` repo) — repos → types → docs
  nav, Meilisearch search, client-side JS markdown rendering with
  sanitization, pluggable auth.

The three designs are Draft with lettered Open Questions for review; the two
service designs are written to be self-contained so they can be copied into
their new repos. DESIGN-0007 is the only one that is work in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)