### PR TITLE
docs: mark IMPL-0013 Completed (post-v0.5.0)

### DIFF
--- a/docs/impl/0013-promote-parsing-core-to-pkgdoczcore.md
+++ b/docs/impl/0013-promote-parsing-core-to-pkgdoczcore.md
@@ -1,7 +1,7 @@
 ---
 id: IMPL-0013
 title: "Promote parsing core to pkg/doczcore"
-status: Draft
+status: Completed
 author: Donald Gifford
 created: 2026-06-30
 ---
@@ -9,7 +9,7 @@ created: 2026-06-30
 
 # IMPL 0013: Promote parsing core to pkg/doczcore
 
-**Status:** Draft
+**Status:** Completed
 **Author:** Donald Gifford
 **Date:** 2026-06-30
 

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -43,5 +43,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0009 | Runner Pattern and DocType Registry Refactor | Completed | 2026-05-15 | Donald Gifford | [0009-runner-pattern-and-doctype-registry-refactor.md](0009-runner-pattern-and-doctype-registry-refactor.md) |
 | IMPL-0011 | Status Set CLI Primitive | Completed | 2026-06-01 | Donald Gifford | [0011-status-set-cli-primitive.md](0011-status-set-cli-primitive.md) |
 | IMPL-0012 | Custom Document Type Support | Completed | 2026-06-18 | Donald Gifford | [0012-custom-document-type-support.md](0012-custom-document-type-support.md) |
-| IMPL-0013 | Promote parsing core to pkg/doczcore | Draft | 2026-06-30 | Donald Gifford | [0013-promote-parsing-core-to-pkgdoczcore.md](0013-promote-parsing-core-to-pkgdoczcore.md) |
+| IMPL-0013 | Promote parsing core to pkg/doczcore | Completed | 2026-06-30 | Donald Gifford | [0013-promote-parsing-core-to-pkgdoczcore.md](0013-promote-parsing-core-to-pkgdoczcore.md) |
 <!-- END DOCZ AUTO-GENERATED -->


### PR DESCRIPTION
## Summary

Mark **IMPL-0013** `Draft -> Completed` (frontmatter + body) now that all
four phases of the `pkg/doczcore` promotion are executed and released in
**v0.5.0** (PR #66 merged; DESIGN-0007 flipped to Implemented in PR #67).
Regenerate the impl README index. Matches the IMPL-0012 post-merge convention.

Docs-only; labeled `dont-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
