### PR TITLE
docs: accept ADR-0001 single public core, add INV-0006 + IMPL-0014

### DIFF
--- a/docs/adr/0001-pkgdoczcore-as-the-single-public-core-cmd-as-a-thin-cli-shell.md
+++ b/docs/adr/0001-pkgdoczcore-as-the-single-public-core-cmd-as-a-thin-cli-shell.md
@@ -1,0 +1,463 @@
+---
+id: ADR-0001
+title: "pkg/doczcore as the single public core; cmd as a thin CLI shell (v1.0.0)"
+status: Accepted
+author: Donald Gifford
+created: 2026-07-03
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# 0001. pkg/doczcore as the single public core; cmd as a thin CLI shell (v1.0.0)
+
+<!--toc:start-->
+- [Status](#status)
+- [Context](#context)
+  - [What the code looks like today (the facts that make this feasible)](#what-the-code-looks-like-today-the-facts-that-make-this-feasible)
+  - [The benchmark](#the-benchmark)
+- [Decision](#decision)
+  - [Scope — what moves](#scope--what-moves)
+  - [The compatibility contract (what v1.0 promises)](#the-compatibility-contract-what-v10-promises)
+- [Consequences](#consequences)
+  - [Positive](#positive)
+  - [Negative](#negative)
+  - [Neutral](#neutral)
+- [Corner Cases](#corner-cases)
+- [Alternatives Considered](#alternatives-considered)
+- [Open Questions](#open-questions)
+  - [1. Package granularity — subpackage family or one flat package?](#1-package-granularity--subpackage-family-or-one-flat-package)
+  - [2. Sequencing against the in-flight v0.6.0?](#2-sequencing-against-the-in-flight-v060)
+  - [3. How do we treat the CLI-shaped packages (template, index, wiki) at v1.0?](#3-how-do-we-treat-the-cli-shaped-packages-template-index-wiki-at-v10)
+  - [4. toc vs docparse overlap in the public API?](#4-toc-vs-docparse-overlap-in-the-public-api)
+  - [5. What remains in internal/ after the move?](#5-what-remains-in-internal-after-the-move)
+  - [6. Embedded templates — how public?](#6-embedded-templates--how-public)
+  - [7. Post-1.0 compatibility & deprecation policy?](#7-post-10-compatibility--deprecation-policy)
+- [Decisions](#decisions)
+- [References](#references)
+<!--toc:end-->
+
+## Status
+
+Accepted (2026-07-03 — all seven open questions resolved; implemented by
+IMPL-0014)
+
+## Context
+
+docz began as a single CLI binary with all logic under `internal/`. As external
+consumers appeared — **docz-api** (DESIGN-0008, cross-repo registry/ingestion),
+**docz-site** (DESIGN-0009, viewer/search), and **sdk-booty-sh** (a doc-driven
+agent-loop harness) — we have been **promoting packages from `internal/` to
+`pkg/doczcore/` one at a time, on demand**:
+
+- `v0.5.0` (DESIGN-0007 / IMPL-0013) promoted `config` + `document` (read side).
+- A `v0.6.0` slate (the sdk-booty-sh requirements handoff,
+  `docz-v0.6.0-requirements.md`) specified a viper-free `config.Load`, a new
+  `pkg/doczcore/docparse`, and the `docwrite` promotion + `CheckTask` — but
+  **none of it exists in code** (no IMPL doc, no `docparse` package, no
+  `CheckTask`, viper still in `Load`; verified 2026-07-03). Per Open
+  Question 2's resolution, no separate `v0.6.0` ships: the slate is part of
+  the `v1.0.0` work.
+
+Each promotion is a separate PR with its own API review and import sweep. That
+per-consumer drip is repetitive, and it means the public surface is defined by
+"whatever a consumer happened to need last," not by a coherent design.
+
+This ADR proposes ending that drip: **establish `pkg/doczcore` as the single
+public core that both the docz CLI and every external consumer build on, and cut
+`v1.0.0` as the first stable, semver-governed release of that surface.**
+
+### What the code looks like today (the facts that make this feasible)
+
+An audit of the current tree (`cmd/` + five `internal/` packages) shows the move
+is mechanically shallow:
+
+- **`cmd/` already imports only `internal/*`, `pkg/doczcore/*`, and stdlib/cobra.**
+  It calls into `internal/{docwrite,template,toc,index,wiki}` and
+  `pkg/doczcore/{config,document}`. There is no third home for logic to hide in.
+- **The internal dependency graph is shallow and one-directional.** Every
+  `internal/*` package depends only on `pkg/doczcore/{config,document}` plus
+  stdlib. The single cross-internal edge is `docwrite → template` (used by
+  `Create`).
+- **The third-party dependency surface is already tiny.** Of the five internal
+  packages, only `wiki` pulls a non-stdlib dependency (`go.yaml.in/yaml/v3`,
+  which is already a core dependency). `docwrite`, `index`, `template`, and `toc`
+  are **stdlib-only**. With viper removed as part of this work, promoting these
+  adds no new heavy dependency to a consumer's build.
+- **One embed.** `//go:embed` appears only in `internal/template`
+  (`templates/*.md`, `templates/*.tmpl`); the embedded files travel with the
+  package wherever it moves.
+
+### The benchmark
+
+The benchmark is twofold: (1) the docz CLI keeps working **exactly as it does
+today** — every command (`init`, `create`, `update`, `list`, `status`,
+`template`, `config`, `wiki`, `version`), output, and exit code unchanged —
+and (2) the public core is **sufficient for every known external consumer**
+(docz-api, docz-site via docz-api, sdk-booty-sh) to build on with zero parser
+drift. The CLI is *not* required to build on `pkg/doczcore` alone: `cmd/` +
+`internal/` presentation code layered over the public core satisfies (1), and
+the INV-0006 demand audit shows the four-package demand core (`config`,
+`document`, `docparse`, `docwrite`) satisfies (2); the adopted scope adds the
+`toc` splice on top (export-lean, Decision 2). This ADR does not remove or
+change any capability; it fixes where the public boundary sits and freezes
+the API behind it.
+
+## Decision
+
+> Revised 2026-07-03 after the INV-0006 per-package demand audit and design
+> review. The original draft moved *all* `internal/` packages public; the
+> revision replaces that with a promotion rule and a smaller frozen core.
+
+1. **Promotion rule — public by default where demand exists, whole packages,
+   named exceptions.** Any package containing a symbol an external consumer
+   requires is promoted **whole** into `pkg/doczcore/*` — package cohesion
+   beats surface minimalism; we do not split a package to hide one function —
+   UNLESS a specific, documented reason keeps machinery private. The embedded
+   template engine is the canonical exception. Packages nothing external
+   needs stay in `internal/`.
+2. **Applied to today's tree** (per the INV-0006 audit plus the export-lean
+   review of 2026-07-03): the public core is
+   `pkg/doczcore/{config,document,docparse,docwrite,toc}`, all landing in
+   the **single `v1.0.0` release** — the planned `v0.6.0` never started, so
+   its slate folds in here:
+   - `config` goes **viper-free** (same `Load` signature, yaml-only —
+     handoff R1);
+   - `docparse` is **created** as the canonical markdown **fact extractor**
+     — `Headings` + `TaskItems` checkbox items, both with byte-accurate
+     1-based line numbers (handoff R2, revised by IMPL-0014 Q3: the
+     `ParsePlan` plan/phase *interpretation* stays consumer-side in
+     sdk-booty-sh — docz parses facts, consumers own meaning);
+   - `docwrite` promotes **whole**: `SetStatus` as-is, the new `CheckTask`
+     (handoff R3), and `Create`/`CreateOptions`/`CreateResult`;
+   - `toc` promotes as the **ToC-splice** package (`GenerateToC`/
+     `UpdateToC`/`UpdateFiles`, the markers), its heading walk delegating to
+     `docparse` — one public parser (Open Question 4a); `toc`'s own
+     `ParseHeadings`/`Heading`/`AnchorSlug` walker retires rather than going
+     public.
+
+   `template`, `index`, and `wiki` remain `internal/`: zero consumer demand,
+   CLI-shaped APIs, and (for `template`) the embed.
+3. **Public packages may depend on `internal/` packages.** This is standard
+   Go — the stdlib does it pervasively — and it is how `docwrite.Create`
+   keeps rendering via `internal/template` without the embed, template
+   names, or render API entering the public contract.
+   `CreateOptions`/`CreateResult` expose only `config` types, primitives,
+   and `time.Time` (verified), so nothing internal leaks through the
+   promoted signature.
+4. **`cmd/` + `internal/` are the CLI product; `pkg/doczcore` is the library
+   product.** "Thin `cmd/`" means no *core logic* in `cmd/` — cobra wiring,
+   the `Runner`, flags, output formatting, exit codes only — not "no
+   `internal/`". `internal/` is the CLI's private half, not a third tier.
+5. **API design principles for the public core:**
+   - **Bytes-in / values-out where possible.** Parsing takes `[]byte`
+     (`ParseFrontmatter`, `docparse.Headings`/`ParsePlan`), not paths, so
+     consumers with no checkout (docz-api) stay first-class.
+   - **No library-defined interfaces.** The core exports concrete functions
+     and structs; consumers define their own small interfaces at the call
+     site. Exported interfaces are the most expensive surface to freeze —
+     adding a method breaks every external implementer.
+   - **Options/result structs over positional parameters** for compound
+     operations (`CreateOptions`/`CreateResult`) — fields evolve additively
+     within the frozen contract.
+   - **Path-based write helpers only where a consumer requires in-place,
+     byte-preserving mutation** (`SetStatus`, `CheckTask`). Any future
+     creation-style API for non-filesystem callers returns
+     `(name, content)` rather than performing I/O.
+6. **`v1.0.0` is the first stable release** of this surface, cut via the
+   `major` release label (0.5.x → 1.0.0; no intermediate `v0.6.0`). Exported
+   identifiers under `pkg/doczcore/*` become a semver-governed compatibility
+   contract. sdk-booty-sh pins `v1.0.0` instead of the formerly planned
+   `v0.6.0` tag.
+7. **The CLI feature set is the completeness benchmark.** v1.0 ships only
+   with **no CLI behavior change**: commands, flags, outputs, and exit codes
+   identical; only import paths and package homes move.
+
+### Scope — what moves
+
+All of this ships in the single `v1.0.0` release:
+
+| Package (today) | v1.0 home | Surface | Notes |
+|---|---|---|---|
+| `pkg/doczcore/config` | unchanged | — | already public (v0.5.0); goes viper-free in this work (handoff R1) |
+| `pkg/doczcore/document` | unchanged | — | already public (v0.5.0); stays read-only |
+| — (new) | `pkg/doczcore/docparse` | new | fact extractor: `Headings` + `TaskItems` with line numbers (handoff R2 as revised by IMPL-0014 Q3 — no plan model) |
+| `internal/docwrite` | `pkg/doczcore/docwrite` | small | **whole package**: `SetStatus`, new `CheckTask` (handoff R3), and `Create` implemented over `internal/template` |
+| `internal/toc` | `pkg/doczcore/toc` | small | the ToC-splice (`GenerateToC`/`UpdateToC`/`UpdateFiles`, markers); walk delegates to `docparse`; its private walker retires |
+| `internal/template` | **stays `internal/`** | — | the named exception: embed + render machinery stay out of the contract |
+| `internal/index` | **stays `internal/`** | — | zero external demand; `UpdateOutcome` is CLI wording (INV-0006 Obs 3) |
+| `internal/wiki` | **stays `internal/`** | — | MkDocs/site-specific; zero external demand |
+| `cmd/*` | unchanged path | — | repoint the `docwrite`/`toc` imports; keep CLI/UX only |
+
+### The compatibility contract (what v1.0 promises)
+
+- **Covered by semver:** every exported identifier under `pkg/doczcore/*`.
+  Breaking changes require a major bump with a deprecation window.
+- **NOT covered:** `cmd/`, any code that remains in `internal/`, `test/`, the
+  CLI's stdout/stderr **text** and exit codes (these get a separate, looser
+  CLI-stability note), and the **contents/names of embedded templates**.
+
+## Consequences
+
+### Positive
+
+- **One coherent public surface**, designed as a whole rather than accreted
+  per-consumer. Consumers import exactly the subpackage they need.
+- **Ends the promotion drip.** No more one-off promotion PRs; the next consumer
+  need is already satisfied (or is a normal additive minor).
+- **`cmd/` becomes a clean, thin shell** — a working reference implementation of
+  the library and a forcing function that keeps logic out of the CLI layer.
+- **Cheap moment to do it.** The dependency surface is already stdlib + `yaml.v3`
+  (viper leaves in the same release); the import graph is shallow; the move is
+  mostly `git mv` + repoint. Pre-1.0 is the last window where the API can be
+  reshaped without a major bump.
+- **An explicit stability guarantee** external consumers can pin — the point of a
+  `v1.0.0`.
+
+### Negative
+
+- **`Create` and the `toc` splice become contract without a consumer.**
+  Promoting `docwrite` whole (cohesion) freezes `Create`'s observable
+  conventions — the `NNNN-slug.md` filename shape, the auto-increment scan,
+  the template-resolution tiers — and promoting `toc` freezes the splice API
+  (`UpdateFiles` and its report categories included) before any external
+  caller exists. Mitigated: options/result/report structs evolve additively,
+  and the filename and ID conventions are already de facto frozen via the
+  public `document.DoczFilePattern`.
+- **Consumers of `docwrite` compile the embed.** The `internal/template`
+  dependency rides along in builds (not in the API). The cost is a handful of
+  embedded markdown templates plus stdlib `text/template` — negligible, but
+  nonzero for a consumer that only wants `SetStatus`.
+- **Support burden.** Public APIs invite bug reports and feature requests
+  against code that was previously ours to change freely — now scoped to the
+  five core packages rather than everything.
+- **A softer "single core" story.** The CLI is *not* a pure `pkg/doczcore`
+  consumer; contributors must learn the rule ("presentation stays internal")
+  rather than a flat "everything is public."
+
+_The original draft's negatives — freezing CLI-shaped `template`/`index`/
+`wiki` APIs under semver, and the demand mismatch of promoting surface no
+consumer asked for — are resolved by the revised scope rather than accepted:
+those packages stay `internal/` (INV-0006)._
+
+### Neutral
+
+- **Dependency graph barely changes.** With viper removed in this release the
+  public core depends on `yaml.v3` + stdlib only; `docparse`, `toc`, and the
+  `docwrite` splice primitives are stdlib-only, and per-subpackage imports
+  mean a consumer of `document` compiles none of the CLI's internal
+  machinery.
+- **Version jump is bookkeeping.** The `major` label drives `v1.0.0` through the
+  existing `pr-semver-bump` + goreleaser automation, same mechanism as prior tags.
+- **No CLI behavior change.** This is a relocation + freeze, not a feature change.
+
+## Corner Cases
+
+1. **Embedded templates as public contract.** Dissolved by the revised scope:
+   `internal/template` does not move, so the `embed.FS`, template names, and
+   template contents can never enter the contract through the public API —
+   no mitigation needed (Open Question 6, now moot).
+2. **`toc` vs `docparse` overlap.** Resolved (Open Question 4a): `docparse`
+   is the canonical — and only — public parser. `toc` promotes as the
+   ToC-splice package (`GenerateToC`/`UpdateToC`/`UpdateFiles`, the markers
+   `cmd/wiki.go` also uses) with its heading walk delegating to `docparse`
+   (public `GenerateToC` takes `[]docparse.Heading`); `toc`'s own
+   `ParseHeadings`/`Heading`/`AnchorSlug` walker retires.
+3. **CLI-shaped return types.** `index.UpdateOutcome` (with an `Action` enum tuned
+   to `cmd`'s user-facing wording) and `wiki`'s nav/mkdocs helpers encode CLI
+   decisions. Freezing them as-is exports those decisions; redesigning them is the
+   real cost (Open Question 3/5).
+4. **`Create` needs `template` — and that's fine.** `internal/docwrite.Create`
+   is the only cross-internal edge (`docwrite → template`). A public package
+   may legally import its own module's `internal/` packages (the stdlib does
+   this pervasively), so the promoted `pkg/doczcore/docwrite` keeps rendering
+   via `internal/template`. Consumers importing `docwrite` compile the embed
+   and `text/template` into their binaries (both stdlib-backed — no new
+   module dependencies), but none of it is importable or part of the
+   contract. What *does* freeze with `Create` is observable behavior: the
+   `NNNN-slug.md` filename convention and the auto-increment scan, both
+   already de facto contract via the public `document.DoczFilePattern`.
+5. **Sequencing against the planned v0.6.0.** Resolved (Open Question 2): the
+   v0.6.0 slate was never started — no IMPL doc, no `docparse`, no
+   `CheckTask`, viper still in `config.Load` (verified 2026-07-03) — so there
+   is nothing to "ship first." The slate is part of the `v1.0.0` work, and
+   sdk-booty-sh pins `v1.0.0` instead of `v0.6.0`. Accepted trade-off: its
+   wait extends by the width of the v1.0-only additions (`Create`, `toc`,
+   the freeze), which is small relative to the slate itself.
+6. **Empty `internal/`?** Moot under the revised scope — `internal/` remains
+   populated (`template`, `index`, `toc` splice, `wiki`) as the CLI's private
+   half (Open Question 5, resolved a).
+7. **`test/consumer/` grows.** The external-module smoke test should exercise the
+   full v1.0 surface (import each subpackage, assert it compiles + runs from
+   outside the module) so accidental surface narrowing is caught.
+8. **Naming / stutter.** A flat `pkg/doczcore` package yields `doczcore.Config`,
+   `doczcore.ParsePlan`, etc.; the subpackage family keeps `config.Config`,
+   `docparse.ParsePlan`. This interacts with Open Question 1.
+9. **No regression to existing pins.** `config` and `document` keep their existing
+   import paths, so v0.5.0/v0.6.0 consumers are unaffected — the consolidation is
+   additive for them.
+
+## Alternatives Considered
+
+- **A. Status quo — promote on demand.** Keep `internal/` as the default and
+  promote a package only when a consumer needs it and its API passes review.
+  *Pros:* minimal semver surface; maximum refactor freedom; each promotion gets a
+  design checkpoint. *Cons:* the recurring per-consumer PR churn this ADR is
+  reacting to; the public surface stays accretive rather than designed.
+- **B. Separate `doczcore` module** (`github.com/donaldgifford/docz-core`) with its
+  own version line. *Pros:* fully decouples library semver from CLI releases.
+  *Cons:* two modules, two release trains, `replace`/pin friction for the CLI
+  itself; heavier than the problem warrants.
+- **C. Flat single `pkg/doczcore` package.** Collapse everything into one package.
+  *Pros:* one import. *Cons:* no per-subpackage tree-shaking; a huge single API;
+  massive rename churn. (Captured as Open Question 1.)
+- **D. This ADR — subpackage family under `pkg/doczcore`, v1.0 freeze.** Promote
+  the remaining logic packages into the existing `pkg/doczcore/*` namespace and
+  commit to semver at v1.0. Chosen as the base for discussion; the open questions
+  below refine it.
+
+## Open Questions
+
+> Each question is numbered; option `a` is my recommendation, later letters are
+> alternatives, and the final letter is a free-form "other" for you to fill in.
+> Answer inline (e.g. `1a`, `3c`) and I'll lock the choices into a Decision before
+> we build the implementation plan.
+>
+> **Update 2026-07-03:** all seven questions are resolved — see the
+> [Decisions](#decisions) table. Implementation is planned in IMPL-0014.
+
+### 1. Package granularity — subpackage family or one flat package?
+
+> **Resolved 2026-07-03: (a)** — implied by the per-package promotion rule
+> (Decision 1) and the INV-0006 per-package audit.
+
+- **a. (Recommended)** Keep the **subpackage family**
+  `pkg/doczcore/{config,document,docparse,docwrite,template,index,toc,wiki}`.
+  Preserves the current split and the typed boundaries, keeps imports
+  tree-shakeable (a consumer of `document` doesn't compile `wiki`), and is minimal
+  churn (mostly `git mv` + repoint).
+- b. Collapse to a **single flat** `pkg/doczcore` package — one import, but no
+  tree-shaking, a very large single surface, and pervasive rename churn.
+- c. Other.
+
+### 2. Sequencing against the in-flight `v0.6.0`?
+
+> **Resolved 2026-07-03: (b), amended by fact-check** — the premise of (a)
+> was wrong: nothing of the v0.6.0 slate exists in code (no IMPL doc, no
+> `docparse`, no `CheckTask`, viper still in `Load`), so there is nothing to
+> ship first. The slate folds into the single `v1.0.0` release;
+> sdk-booty-sh pins `v1.0.0`.
+
+- **a. (Recommended)** **Ship `v0.6.0` (IMPL-0014) first** to unblock sdk-booty-sh
+  (it is waiting on the tag), then do this consolidation as `v1.0.0`. Two clean
+  releases; the blocked consumer isn't held hostage to the big refactor.
+- b. **Fold everything into one `v1.0.0`** and drop the separate `v0.6.0` — fewer
+  releases, but delays the waiting consumer behind the larger, riskier change.
+- c. Other (e.g. ship `v0.6.0`, then a `v0.7.0` staging release, then `v1.0.0`).
+
+### 3. How do we treat the CLI-shaped packages (`template`, `index`, `wiki`) at v1.0?
+
+> **Resolved 2026-07-03: none of the drafted options** — they stay
+> `internal/` (zero demand, INV-0006), while `docwrite` promotes **whole**
+> (incl. `Create`, implemented over `internal/template`). See Decisions.
+
+- **a. (Recommended)** **Promote with a light naming/doc review** and accept the
+  current shapes as v1.0 API (the benchmark is "cmd works unchanged"). Fastest path
+  to v1.0; we can deprecate/refine later within semver.
+- b. **Redesign each for general public use** before freezing (e.g. decouple
+  `index.UpdateOutcome` from CLI wording, generalize `wiki` beyond MkDocs). Cleaner
+  long-term API, materially more work, delays v1.0.
+- c. **Promote but mark `template`/`index`/`wiki` as `experimental`/`unstable`**
+  (documented as *exempt* from the v1.0 compatibility guarantee) so the *needed*
+  core (`config`/`document`/`docparse`/`docwrite`) is stable while the CLI-shaped
+  packages keep refactor freedom. A middle path that limits the semver cost.
+- d. Other.
+
+### 4. `toc` vs `docparse` overlap in the public API?
+
+> **Resolved 2026-07-03: (a)** — export-lean: the splice is document
+> machinery (bytes-in content transforms), not CLI presentation, so it
+> promotes to `pkg/doczcore/toc` delegating its walk to `docparse`. One
+> public parser; `toc`'s own walker retires.
+
+- **a. (Recommended)** `docparse` is the **canonical parser**; keep a
+  `pkg/doczcore/toc` for the **ToC-splice** concern
+  (`GenerateToC`/`UpdateToC`/`UpdateFiles`) that **delegates** to `docparse` for
+  the heading walk — one parser, ToC generation layered on top.
+- b. **Fold the ToC-splice into `docparse`** (single package owns both parse and
+  ToC rendering) — fewer packages, but mixes "parse" and "render" concerns.
+- c. Keep `toc` independent with its own walker (accept two parsers in public).
+- d. Other.
+
+### 5. What remains in `internal/` after the move?
+
+> **Resolved 2026-07-03: (a)**, strengthened — `internal/` stays *populated*
+> (`template`, `index`, `toc` splice, `wiki`), not merely available.
+
+- **a. (Recommended)** **Keep `internal/` available** as the sanctioned home for
+  genuinely CLI-private helpers (none today, but the door stays open), while moving
+  all current logic out. `cmd/` holds UX/wiring; `internal/` holds CLI-only glue if
+  any arises.
+- b. **Delete `internal/` entirely**; anything CLI-private lives directly in
+  `cmd/`. Strongest "single core" statement, least flexibility.
+- c. Other.
+
+### 6. Embedded templates — how public?
+
+> **Resolved 2026-07-03: moot** — `template` never promotes; the embed stays
+> private behind the `internal/` boundary.
+
+- **a. (Recommended)** Move `templates/` with `pkg/doczcore/template`, keep the
+  `embed.FS` **package-private**, and expose only accessor functions
+  (`EmbeddedDocumentTemplate`, etc.). **Exclude template file names/contents from
+  the compatibility contract** so we can edit built-in templates freely.
+- b. **Export the `embed.FS`** for full consumer access to raw templates — maximal
+  flexibility for consumers, but freezes template names/paths as public contract.
+- c. Other.
+
+### 7. Post-1.0 compatibility & deprecation policy?
+
+> **Resolved 2026-07-03: (a), simplified — roll forward.** Standard semver
+> coverage as drafted; breaking changes ship in a major bump. No mandatory
+> deprecation window — `Deprecated:` markers when practical, then roll
+> forward.
+
+- **a. (Recommended)** Standard semver: exported identifiers under
+  `pkg/doczcore/*` are covered; `cmd/`, `internal/`, `test/`, CLI output **text**,
+  and embedded template contents are **not**. Breaking changes ship in a major bump
+  after a documented deprecation window (one minor with `Deprecated:` markers).
+- b. A stricter/looser variant (specify).
+- c. Other.
+
+## Decisions
+
+Resolved by review on 2026-07-03, grounded in the INV-0006 per-package demand
+audit and the export-lean review. All seven questions are closed; IMPL-0014
+carries the implementation plan.
+
+| #   | Question                          | Choice                                        | Notes                                                                                                                       |
+| --- | --------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Package granularity               | (a) subpackage family                         | implied by the per-package promotion rule; INV-0006 audits package-by-package                                               |
+| 2   | Sequencing vs `v0.6.0`            | fold into one `v1.0.0`                        | nothing of the slate exists in code (verified 2026-07-03); no separate `v0.6.0` ships; sdk-booty-sh pins `v1.0.0`           |
+| 3   | CLI-shaped packages at v1.0       | `template`/`index`/`wiki` stay `internal/`; `docwrite` promotes whole | zero external demand for the three (INV-0006); `Create` joins public `docwrite` at v1.0 over `internal/template` |
+| 4   | `toc` vs `docparse`               | (a) one parser, both public                   | `docparse` canonical; `toc` promotes as the splice package delegating to it; `toc`'s private walker retires                 |
+| 5   | What remains in `internal/`       | (a) keep `internal/`, populated               | `template`, `index`, `wiki` — the CLI's private half                                                                        |
+| 6   | Embedded templates                | moot                                          | `template` never promotes; embed stays private                                                                              |
+| —   | CLI-shaped `config` helpers       | keep                                          | `TypesHelp`/`DefaultNavTitles`/`ResolveTypeAlias` stay public (export-lean); documented as CLI-support (INV-0006 Q4a)       |
+| 7   | Post-1.0 compat policy            | (a) simplified — roll forward                 | standard semver coverage; breaking changes = major bump; no mandatory deprecation window (`Deprecated:` markers when practical) |
+| —   | API design principles             | adopted (Decision 5)                          | bytes-in/values-out; no library-defined interfaces; options/result structs; path-writers only on consumer demand            |
+
+## References
+
+- **INV-0006** — per-package core requirements audit (docz CLI vs docz-api,
+  docz-site, sdk-booty-sh): the demand evidence behind the revised scope.
+- **IMPL-0014** — the implementation plan for this ADR (all six phases of
+  the single `v1.0.0` release). Note: the IMPL-0014 id was once informally
+  reserved for a standalone-`v0.6.0` plan that was never written; the id now
+  belongs to the v1.0.0 plan.
+- **ADR context / prior art** — DESIGN-0007 (`pkg/doczcore` public surface,
+  read-only stance), IMPL-0013 (`v0.5.0` promotion), and the
+  `docz-v0.6.0-requirements.md` handoff (R1–R3), whose slate ships inside
+  `v1.0.0`.
+- **Consumers** — DESIGN-0008 (docz-api), DESIGN-0009 (docz-site), the
+  `sdk-booty-sh` v0.6.0 requirements handoff (loop harness).
+- **Release mechanism** — `pr-semver-bump` (`major` label → `v1.0.0`) + goreleaser,
+  same path as prior tags.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,4 +31,5 @@ docz create adr "Your ADR Title"
 
 | ID | Title | Status | Date | Author | Link |
 |----|-------|--------|------|--------|------|
+| ADR-0001 | pkg/doczcore as the single public core; cmd as a thin CLI shell (v1.0.0) | Accepted | 2026-07-03 | Donald Gifford | [0001-pkgdoczcore-as-the-single-public-core-cmd-as-a-thin-cli-shell.md](0001-pkgdoczcore-as-the-single-public-core-cmd-as-a-thin-cli-shell.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0014-v100-the-five-package-pkgdoczcore-public-core.md
+++ b/docs/impl/0014-v100-the-five-package-pkgdoczcore-public-core.md
@@ -1,0 +1,541 @@
+---
+id: IMPL-0014
+title: "v1.0.0: the five-package pkg/doczcore public core"
+status: Draft
+author: Donald Gifford
+created: 2026-07-03
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0014: v1.0.0: the five-package pkg/doczcore public core
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-07-03
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Affected code (verified inventory)](#affected-code-verified-inventory)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 1: viper-free config.Load (handoff R1)](#phase-1-viper-free-configload-handoff-r1)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 2: create pkg/doczcore/docparse (handoff R2, revised)](#phase-2-create-pkgdoczcoredocparse-handoff-r2-revised)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 3: promote docwrite whole + add CheckTask (handoff R3)](#phase-3-promote-docwrite-whole--add-checktask-handoff-r3)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 4: promote toc as the splice package over docparse (ADR-0001 OQ4a)](#phase-4-promote-toc-as-the-splice-package-over-docparse-adr-0001-oq4a)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 5: consumer proof + public-surface hygiene](#phase-5-consumer-proof--public-surface-hygiene)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+  - [Phase 6: living docs, release, and the v1.0.0 tag](#phase-6-living-docs-release-and-the-v100-tag)
+    - [Tasks](#tasks-5)
+    - [Success Criteria](#success-criteria-5)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+  - [1. PR strategy — per-phase PRs or one atomic PR?](#1-pr-strategy--per-phase-prs-or-one-atomic-pr)
+  - [2. Unknown-key handling in the yaml-only Load?](#2-unknown-key-handling-in-the-yaml-only-load)
+  - [3. ParsePlan phase semantics — which ### headings are phases?](#3-parseplan-phase-semantics--which--headings-are-phases)
+  - [4. Does the UpdateFiles family go public with toc?](#4-does-the-updatefiles-family-go-public-with-toc)
+- [Decisions](#decisions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Implement **ADR-0001** as a single `v1.0.0` release: make `config.Load`
+viper-free, create `pkg/doczcore/docparse` (heading + checkbox-task fact
+extraction with byte-accurate line numbers — no plan interpretation, see
+Decisions Q3), promote `internal/docwrite` **whole** (`SetStatus`,
+`Create`, plus the new `CheckTask`), promote `internal/toc` as the ToC-splice
+package delegating its walk to `docparse`, and freeze the resulting
+five-package surface — `pkg/doczcore/{config,document,docparse,docwrite,toc}`
+— under semver via the `major` release label. `template`, `index`, and `wiki`
+remain `internal/`.
+
+The change is **behavior-preserving for the CLI**: no command, flag, output,
+or `.docz.yaml`/frontmatter schema change; golden files must not move. There
+is **no intermediate `v0.6.0`** — the sdk-booty-sh slate
+(`docz-v0.6.0-requirements.md` R1–R3) ships inside this release, and
+sdk-booty-sh pins the `v1.0.0` tag (ADR-0001 Decision / OQ2).
+
+**Implements:** ADR-0001 (grounded in the INV-0006 per-package audit; absorbs
+the `docz-v0.6.0-requirements.md` handoff R1–R3).
+
+> **Numbering note:** earlier docs (ADR-0001's first draft) referred to a
+> planned "IMPL-0014" covering a standalone v0.6.0. That plan was never
+> written; this document takes the IMPL-0014 id and covers the full v1.0.0.
+
+## Scope
+
+### In Scope
+
+- **Viper-free `config.Load`** (handoff R1): same exported signature,
+  yaml-only implementation; `github.com/spf13/viper` (and its `mapstructure`
+  indirect) leave `go.mod` entirely — `cmd/` has no direct viper import
+  (verified 2026-07-03).
+- **New `pkg/doczcore/docparse`** (handoff R2, **revised** — Decisions Q3):
+  two fact-extraction primitives with 1-based `Line` — `Headings` and
+  `TaskItems` (every checkbox list item: fence-aware, `-`/`*`-bullet
+  tolerant, `Indent` exposed) — absorbing the `internal/toc` walker and its
+  `AnchorSlug` slug logic. The `Plan`/`Phase` **interpretation** moves to
+  sdk-booty-sh's `doczwork`, built on these primitives.
+- **`internal/docwrite` → `pkg/doczcore/docwrite`, whole** (handoff R3 +
+  ADR-0001 Decision 2): `SetStatus` as-is, `Create` as-is (keeping its
+  `internal/template` import — public→internal is legal, ADR-0001
+  Decision 3), plus the new `CheckTask` byte-splice.
+- **`internal/toc` → `pkg/doczcore/toc`** (ADR-0001 OQ4a): the splice
+  surface (`GenerateToC`/`UpdateToC`/`UpdateFiles`, `BeginMarker`/
+  `EndMarker`); its private walker (`ParseHeadings`/`Heading`/`AnchorSlug`)
+  retires in favor of `docparse`.
+- **Consumer-proof + hygiene**: `test/consumer/` exercises all five
+  subpackages; package doc comments; `TypesHelp`/`DefaultNavTitles`/
+  `ResolveTypeAlias` documented as CLI-support helpers.
+- **Docs + release**: living-doc updates, dated DESIGN-0007 amendment,
+  absorb + delete the root handoff file, `major`-labeled PR → `v1.0.0`.
+
+### Out of Scope
+
+- **Promoting `template`, `index`, or `wiki`** — they stay `internal/`
+  (ADR-0001 Decisions; zero external demand per INV-0006).
+- **Any CLI behavior change** — no new commands, flags, outputs, or exit
+  codes; the CLI may only change import paths.
+- **Any `.docz.yaml` / frontmatter schema change.**
+- **The plan/phase model** (`ParsePlan`, phase grouping, `#### Tasks`
+  scoping, nesting policy) — consumer-side interpretation, owned by
+  sdk-booty-sh's `doczwork` on top of the `docparse` primitives (Decisions
+  Q3: docz parses *facts*; consumers own *meaning*).
+- **A general markdown AST/editing API** — the write surface stays
+  status + checkbox + create, by design.
+- **Frontmatter editing beyond status; CRLF support** (LF-only stays the
+  contract).
+- **Reshaping `Create`** (e.g. a pure `PlanCreate` seam) — deferred until a
+  consumer asks; it promotes with its current shape.
+- **`docz export --json`** (still deferred, DESIGN-0007 OQ3a).
+- **Module-path change** — `v1.x` requires no `/vN` suffix (that starts at
+  v2).
+
+## Affected code (verified inventory)
+
+- `pkg/doczcore/config/config.go` — viper's only home: `Load` →
+  `mergeConfigFile` / `loadFromFile` / `viper.New` call sites. All structs
+  already carry dual `mapstructure` + `yaml` tags. `cmd/` has **no** direct
+  viper import, so `go mod tidy` drops viper + the `mapstructure` indirect
+  after Phase 1.
+- `internal/docwrite/` — `create.go` (imports `internal/template` for
+  `Resolve`/`Render`/`FilenameSlug` — the only cross-internal edge),
+  `status.go` (+ sentinels), tests, and
+  `testdata/golden/status/<type>.{input,output}.md` — all move wholesale.
+  `CreateOptions`/`CreateResult` expose only `config` types, primitives, and
+  `time.Time` (verified) — no internal type leaks through promotion.
+- `internal/toc/` — `toc.go` (walker + `GenerateToC`/`UpdateToC` + markers),
+  `update.go` (`UpdateFiles`, `FileInput{Path, Content}`, `FileResult`,
+  `FileError`, `UpdateReport`), `toc_test.go`, `update_test.go`,
+  `golden_test.go`.
+- `cmd/` repoints: `status.go` + `create.go` (docwrite), `update.go` (the
+  only non-test `toc` importer — verified).
+- `.golangci.yml` — **no** `internal/toc`/`internal/docwrite` path pins exist
+  (verified); nothing to update, re-check after the moves.
+- `test/consumer/` — separate module; extend to the full surface.
+- Living docs: `CLAUDE.md` (incl. the "Cobra/Viper for CLI" conventions
+  line), `CONTRIBUTING.md`, `DEVELOPMENT.md`, `README.md` if it names paths.
+- `docs/design/0007-…` — dated amendment (write surface). Root
+  `docz-v0.6.0-requirements.md` — deleted once absorbed here.
+
+## Implementation Phases
+
+Each phase builds on the previous one. A phase is complete when all its tasks
+are checked off and its success criteria are met. Phases 1–4 are independent
+except **Phase 4 depends on Phase 2** (the `docparse` delegation).
+
+---
+
+### Phase 1: viper-free `config.Load` (handoff R1)
+
+Swap the config decode engine without moving a single symbol: yaml.v3
+decoding onto a pre-populated `DefaultConfig()`, preserving every observable
+behavior the tests pin.
+
+#### Tasks
+
+- [ ] Replace the viper path (`mergeConfigFile`, `loadFromFile`, the
+      `viper.New` call sites in `Load`) with `go.yaml.in/yaml/v3` decoding
+      onto a pre-populated `DefaultConfig()` (the `yaml` tags are already on
+      every struct), preserving: defaults fill, `.docz.yaml` discovery from
+      `repoRoot`, explicit `configFile` override, types-replace-on-presence,
+      and validation order.
+- [ ] Keep the exported signature byte-identical:
+      `Load(configFile, repoRoot string) (Config, error)`.
+- [ ] Apply Open Question 2's resolution for unknown-key handling (default
+      posture: lenient, viper-parity).
+- [ ] Audit error-path wording: malformed-YAML messages may differ from
+      viper's — exit codes and success paths must not; note any wording
+      delta for the release notes.
+- [ ] `go mod tidy` — confirm `github.com/spf13/viper` and the
+      `go-viper/mapstructure` indirect leave `go.mod`/`go.sum`.
+- [ ] Extend the parity baseline test to pin the **case-sensitivity delta**:
+      lowercase keys behave identically; a MixedCase key is no longer
+      matched (documented, not honored — viper was case-insensitive).
+- [ ] Draft the release-notes lines: viper removal, case-sensitivity delta,
+      any error-wording changes.
+
+#### Success Criteria
+
+- A scratch module importing only `pkg/doczcore/{config,document}` shows
+  **no** `github.com/spf13/viper` packages in `go list -deps` (the handoff
+  R1 acceptance test).
+- `make test` green including the parity baseline;
+  `go test ./... -update` produces **zero** golden churn.
+- `cmd/` tests untouched except (at most) pinned error-text updates, each
+  flagged in the PR description.
+
+---
+
+### Phase 2: create `pkg/doczcore/docparse` (handoff R2, revised)
+
+The canonical markdown **fact extractor**: one heading walker and one
+checkbox walker for the whole module — byte-accurate lines, zero
+interpretation. The plan/phase model is deliberately absent (Decisions Q3):
+sdk-booty-sh's `doczwork` builds it on these primitives.
+
+#### Tasks
+
+- [ ] Create the package — bytes-in/values-out (ADR-0001 Decision 5):
+      `Heading{Level, Text, Slug, Line}`,
+      `Headings(content []byte) []Heading`.
+- [ ] Port the `internal/toc` walker semantics — fence-aware, H2–H6 (H1
+      excluded), inline-markdown stripping, GitHub-compatible slugs — adding
+      1-based `Line`; move the `AnchorSlug` slug logic here (exported), with
+      slug output **byte-identical** to `internal/toc`'s on its existing
+      test corpus.
+- [ ] Add the checkbox primitive:
+      `TaskItem{Text, Checked, Indent, Line}`,
+      `TaskItems(content []byte) []TaskItem` — every `- [ ]` / `- [x]` list
+      item (`-` or `*` bullets, marker stripped from `Text`), fence-aware
+      (checkboxes inside code fences ignored), LF-only line accounting
+      matching `docwrite`'s contract so `TaskItem.Line` feeds `CheckTask`
+      directly; `Indent` (leading-whitespace width) exposed so consumers
+      apply their own top-level/nesting policy. **No** phase grouping, no
+      `#### Tasks` scoping — facts only.
+- [ ] Golden fixtures: template-conformant IMPL output **and** a messy
+      hand-written corpus; add a write-through test that byte-splices at
+      reported `TaskItem.Line` values against the raw file bytes.
+- [ ] Package doc comment (stating the facts-not-interpretation contract) +
+      goheader license headers.
+
+#### Success Criteria
+
+- Slug parity: `docparse` slugs byte-identical to `internal/toc`'s across
+  toc's existing corpus (pre-work for Phase 4's zero-churn guarantee).
+- `TaskItem.Line` values verified against raw bytes (a consumer will write
+  through them); golden tests green; the package is **stdlib-only**.
+
+---
+
+### Phase 3: promote `docwrite` whole + add `CheckTask` (handoff R3)
+
+The write side goes public as one cohesive package: status splice, checkbox
+splice, and document creation — with the template machinery staying private
+behind it.
+
+#### Tasks
+
+- [ ] `git mv internal/docwrite pkg/doczcore/docwrite` (package name
+      `docwrite` preserved, `testdata/golden/status/` rides along);
+      `create.go` keeps its `internal/template` import (public→internal,
+      legal — ADR-0001 Decision 3).
+- [ ] Add `CheckTask(path string, line int) error`: flips the unchecked
+      top-level checkbox item on the given 1-based line to checked
+      (`[ ]` → `[x]`), changing **exactly the three marker bytes**; typed,
+      distinguishable sentinels for line-out-of-range / not-a-task-item /
+      task-already-checked; reject CR/CRLF via the existing
+      `ErrUnsupportedLineEndings`; same read-whole-file / single-splice /
+      write-back approach as `SetStatus`.
+- [ ] Repoint `cmd/status.go` and `cmd/create.go` to
+      `pkg/doczcore/docwrite`.
+- [ ] Golden byte-diff tests for `CheckTask`: the on-disk diff touches
+      exactly one line, byte-identical elsewhere; existing
+      `SetStatus`/`Create` tests pass unchanged from the new import path.
+- [ ] Package doc comment stating the deliberate write surface — status +
+      checkbox + create; **not** a general editor.
+- [ ] Add the dated amendment to DESIGN-0007: the read-only-public stance is
+      revised; the public write surface is status + checkbox + create, by
+      design (per ADR-0001).
+
+#### Success Criteria
+
+- `grep -rn 'docz/internal/docwrite' --include='*.go'` returns zero.
+- `CheckTask` golden diffs are single-line; `make test` green with zero
+  churn on the existing status fixtures; CLI behavior identical.
+
+---
+
+### Phase 4: promote `toc` as the splice package over `docparse` (ADR-0001 OQ4a)
+
+One public parser: `toc` keeps the marker-splice concern and delegates every
+heading walk to `docparse`. Depends on Phase 2.
+
+#### Tasks
+
+- [ ] `git mv internal/toc pkg/doczcore/toc`; retire `ParseHeadings`,
+      `Heading`, and `AnchorSlug` from the surface — all walking goes
+      through `docparse.Headings`.
+- [ ] Reshape the delegating surface:
+      `GenerateToC(headings []docparse.Heading, minHeadings int) string`;
+      `UpdateToC` delegates internally and `UpdateResult.Headings` becomes
+      `[]docparse.Heading`; keep `BeginMarker`/`EndMarker` exported; the
+      `UpdateFiles` family per Open Question 4's resolution.
+- [ ] Repoint `cmd/update.go` (the only non-test `toc` importer).
+- [ ] Move `toc_test.go`/`update_test.go`/`golden_test.go` and fixtures;
+      adapt to the `docparse` types; assert generated ToC output is
+      **byte-identical** on the existing corpus.
+- [ ] Package doc comment + license headers.
+
+#### Success Criteria
+
+- Exactly one heading walker in the public API — `go doc ./pkg/doczcore/toc`
+  lists no `ParseHeadings`/`Heading`/`AnchorSlug`.
+- `grep -rn 'docz/internal/toc' --include='*.go'` returns zero; zero golden
+  churn (ToC output byte-identical); `make test` green.
+
+---
+
+### Phase 5: consumer proof + public-surface hygiene
+
+Prove the whole v1.0 surface from outside the module and make it read like a
+deliberate API before it freezes.
+
+#### Tasks
+
+- [ ] Extend `test/consumer/` to import **all five** subpackages by public
+      path and exercise: viper-free
+      `Load → Validate → EnabledTypes → ScanDocuments` (incl. a custom
+      type); `docparse.Headings` + `TaskItems` on fixture bytes;
+      `SetStatus` + `CheckTask` round-trips in `t.TempDir()`; `Create` into
+      `t.TempDir()` (exercising the embedded template through the private
+      engine); a `toc.UpdateToC` splice.
+- [ ] Spot-check and record in the PR: temporarily narrowing a promoted
+      symbol breaks the consumer build; `internal/template` is **not**
+      importable from the consumer module.
+- [ ] `go doc` review of all five packages: doc comments present, intended
+      surface only; document `TypesHelp`/`DefaultNavTitles`/
+      `ResolveTypeAlias` as CLI-support helpers in the `config` package doc
+      (ADR-0001 Decisions).
+- [ ] Re-verify `.golangci.yml` needs no path updates after the moves;
+      `make lint` and the goheader license check green.
+
+#### Success Criteria
+
+- `make ci` green including the consumer module; every public subpackage is
+  exercised by an external importer.
+- The narrowing spot-check fails compilation as expected (recorded once).
+
+---
+
+### Phase 6: living docs, release, and the v1.0.0 tag
+
+Land the freeze as a pinnable contract and close the loop with the waiting
+consumer.
+
+#### Tasks
+
+- [ ] Update `CLAUDE.md` (architecture bullets: `docwrite`/`toc` new homes,
+      `docparse` addition, viper gone — including the "Cobra/Viper for CLI"
+      conventions line), `CONTRIBUTING.md`, `DEVELOPMENT.md`, and `README.md`
+      as needed. **Historical `docs/*` records stay untouched.**
+- [ ] Delete the root `docz-v0.6.0-requirements.md` handoff — its R1–R3
+      slate is fully absorbed by Phases 1–3 of this plan.
+- [ ] Write the PR's `### RELEASE NOTES`: the v1.0.0 stability contract
+      (five-package surface; semver covers exported identifiers under
+      `pkg/doczcore/*`; `cmd/`, `internal/`, `test/`, CLI output text, and
+      embedded template contents excluded; roll-forward posture — breaking
+      changes ship in a major bump, ADR-0001 OQ7); viper removal + the
+      case-sensitivity delta; note that v1 requires no module-path change.
+- [ ] The release PR carries the **`major`** label; on merge,
+      `pr-semver-bump` + goreleaser cut and publish **`v1.0.0`** (merge to
+      `main` is human-gated).
+- [ ] Post-tag: flip this IMPL → Completed; notify sdk-booty-sh — its
+      IMPL-0002 Phase 0/W gate now pins `v1.0.0` (not `v0.6.0`).
+
+#### Success Criteria
+
+- The `v1.0.0` tag exists with a successful goreleaser release; a scratch
+  module can `go get github.com/donaldgifford/docz@v1.0.0` and import all
+  five subpackages.
+- No living doc references `internal/docwrite`/`internal/toc` or claims the
+  module uses viper; the full golden suite shows zero churn (CLI
+  byte-identical).
+
+---
+
+## File Changes
+
+| File / path | Action | Description |
+|------|--------|-------------|
+| `pkg/doczcore/config/config.go` | Modify | viper → yaml.v3 decode onto `DefaultConfig()`; signature unchanged |
+| `go.mod` / `go.sum` | Modify | drop `spf13/viper` + `mapstructure` indirect (`go mod tidy`) |
+| `pkg/doczcore/docparse/*` | Create | `Headings`/`TaskItems` + types (facts only); golden fixtures under `testdata/` |
+| `pkg/doczcore/docwrite/*` | Move | `git mv` from `internal/docwrite` (incl. `testdata/golden/status/`); keeps `internal/template` import |
+| `pkg/doczcore/docwrite/checktask.go` | Create | `CheckTask` + typed sentinels + byte-diff goldens |
+| `pkg/doczcore/toc/*` | Move | `git mv` from `internal/toc`; walker retired, delegates to `docparse` |
+| `cmd/status.go`, `cmd/create.go`, `cmd/update.go` | Modify | repoint imports to `pkg/doczcore/{docwrite,toc}` |
+| `test/consumer/*` | Modify | exercise all five public subpackages |
+| `docs/design/0007-…` | Modify | dated amendment: write surface = status + checkbox + create |
+| `CLAUDE.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `README.md` | Modify | repoint living-doc references; drop viper mentions |
+| `docz-v0.6.0-requirements.md` (repo root) | Delete | absorbed by Phases 1–3 |
+
+## Testing Plan
+
+- [ ] **Moved tests pass unchanged except import paths** — `docwrite` status
+      goldens and `toc` splice goldens prove behavior preserved;
+      `go test ./... -update` yields zero churn at every phase boundary.
+- [ ] **Parity baseline pins the config decode** — including the new
+      case-sensitivity case (Phase 1).
+- [ ] **`docparse` golden corpus** — template-conformant + messy fixtures;
+      slug parity vs the old walker; `TaskItem.Line` write-through accuracy.
+- [ ] **`CheckTask` byte-diff goldens** — exactly one line changes.
+- [ ] **CLI regression suite stays green** — `cmd/` tests (serial `Runner` +
+      `bytes.Buffer`) untouched except imports and any flagged error-text
+      pins.
+- [ ] **Consumer module exercises all five subpackages** as an external
+      importer (Phase 5).
+- [ ] **`make ci` gates every phase** — lint, license-check, build, full
+      suite, consumer module.
+
+## Dependencies
+
+- **None external.** Self-contained single-repo work; all callers are
+  in-repo and compiler-verified. Phase 4 depends on Phase 2 (`docparse`).
+- **Enables (does not depend on):** sdk-booty-sh IMPL-0002 Phase 0/W — its
+  work-source harness waits on the `v1.0.0` tag (its policy: no `replace`
+  directives). docz-api continues on `v0.5.0` unaffected (its surface is
+  untouched; the consolidation is additive for it).
+- **Tooling:** existing `pr-semver-bump` (label `major`) + goreleaser.
+
+## Open Questions
+
+> Each question is numbered; option `a` is my recommendation, later letters
+> are alternatives, and the final letter is a free-form "other" for you to
+> fill in. Answer inline (e.g. `1a`, `3c`) and I'll lock them into a
+> Decisions table before implementation starts.
+>
+> **Update 2026-07-03:** all four questions are resolved (`1a 2a 3d 4a`) —
+> see the [Decisions](#decisions) table. The menus below are kept for the
+> record.
+
+### 1. PR strategy — per-phase PRs or one atomic PR?
+
+> **Resolved: (a).**
+
+- **a. (Recommended)** **Sequential per-phase PRs to `main`** — P1 (viper),
+  P2 (docparse), P3 (docwrite), P4 (toc), P5+P6 (consumer/hygiene/release) —
+  each labeled `dont-release`, with the final PR carrying `major`. Every
+  merge leaves `main` green and untagged; diffs stay reviewable; each phase
+  reverts independently. Sequential (each merges before the next opens), not
+  stacked — avoiding the stacked-PR auto-close gotcha.
+- b. **One atomic PR** with the `major` label (IMPL-0013 style) — a single
+  revert unit, but a very large diff: dependency removal + a new package +
+  two package moves + a reshape in one review.
+- c. **Two PRs**: the core slate (Phases 1–4, `dont-release`) + the
+  hygiene/release PR (Phases 5–6, `major`).
+- d. Other.
+
+### 2. Unknown-key handling in the yaml-only `Load`?
+
+> **Resolved: (a).**
+
+- **a. (Recommended)** **Lenient** — ignore unknown keys (yaml.v3's
+  default), matching viper's behavior exactly: a typo'd key silently falls
+  back to defaults, as today. Zero behavior change; keeps "the CLI works
+  exactly as it does today" literal.
+- b. **Strict** (`KnownFields(true)`) — fail fast on unknown keys. Catches
+  `.docz.yaml` typos early, but it is a behavior change (configs that load
+  today could start erroring) and needs its own release-note callout and a
+  test sweep.
+- c. Other.
+
+### 3. `ParsePlan` phase semantics — which `###` headings are phases?
+
+> **Resolved: (d) — the question dissolves: `ParsePlan` is dropped from
+> `docparse`.** docz parses *facts* (headings, checkbox items — with
+> byte-accurate lines that feed `CheckTask`); the plan/phase
+> *interpretation* is loop-harness policy and moves to sdk-booty-sh's
+> `doczwork`, built on the primitives. Every option below was docz picking a
+> workflow semantic it has no use for itself — the ambiguity was the signal
+> that the semantics belong downstream. Handoff R2 is revised accordingly:
+> `docparse` ships `Headings` + `TaskItems` instead of `ParsePlan`.
+
+- **a. (Recommended)** **Handoff-literal**: every `###` heading opens a
+  phase (bold names tolerated); phases with no checkbox tasks are included
+  with an empty `Tasks` slice; consumers filter. Simplest contract, no
+  magic English heading names, and it matches the messy-corpus leniency
+  intent — a hand-written doc with tasks under an unconventional heading
+  still parses.
+- b. **Scope to the `## Implementation Phases` section** when that heading
+  exists, else fall back to (a). Cleaner output for template-conformant
+  docs (no "Observation 1"-style pseudo-phases), but a two-mode contract
+  keyed to an English heading name that custom templates may not use.
+- c. **Task-bearing headings only** — a `###` heading becomes a phase only
+  if it contains at least one checkbox. Smallest output, but silently drops
+  genuinely empty phases (e.g. a planned phase whose tasks aren't written
+  yet), which a harness may want to see.
+- d. Other.
+
+### 4. Does the `UpdateFiles` family go public with `toc`?
+
+> **Resolved: (a).**
+
+- **a. (Recommended)** **Yes — promote the package whole**: `UpdateFiles`,
+  `FileInput{Path, Content}`, `FileResult`, `FileError`, `UpdateReport` all
+  go public. Consistent with the ADR-0001 whole-package rule; the
+  write-back mirrors `docwrite`'s path-writer precedent; the report structs
+  evolve additively.
+- b. **No — keep the file-walking layer CLI-side** (a small helper in
+  `cmd/` or `internal/`): public `toc` is the pure
+  `GenerateToC`/`UpdateToC` + markers. A purer bytes-in surface, but it
+  re-introduces exactly the split-package layout ADR-0001 Decision 1
+  rejects.
+- c. Other.
+
+## Decisions
+
+Resolved by user review on 2026-07-03.
+
+| #   | Question                     | Choice                              | Notes                                                                                                                    |
+| --- | ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 1   | PR strategy                  | (a) sequential per-phase PRs        | each `dont-release`; the final release PR carries `major`; sequential, not stacked                                       |
+| 2   | Unknown-key handling         | (a) lenient                         | viper parity — zero behavior change                                                                                      |
+| 3   | `ParsePlan` phase semantics  | (d) drop `ParsePlan` — facts only   | `docparse` ships `Headings` + `TaskItems`; the Plan/Phase model moves to sdk-booty-sh `doczwork` (handoff R2 revised)     |
+| 4   | `UpdateFiles` publicity      | (a) whole package                   | consistent with the ADR-0001 whole-package rule                                                                          |
+
+## References
+
+- **ADR-0001** — the decision this plan implements (promotion rule, five
+  packages, API design principles, single-release sequencing, roll-forward
+  compat posture; all seven OQs resolved 2026-07-03).
+- **INV-0006** — the per-package demand audit (cmd vs docz-api / docz-site /
+  sdk-booty-sh) grounding the scope.
+- **`docz-v0.6.0-requirements.md`** — the sdk-booty-sh handoff (R1 viper-free
+  Load, R2 docparse, R3 docwrite + CheckTask), absorbed by Phases 1–3 and
+  deleted in Phase 6. **R2 is revised by Decisions Q3**: docz ships the
+  `Headings`/`TaskItems` fact primitives; the `ParsePlan` plan model moves
+  to the consumer (the handoff itself notes its shapes are "a consumer's
+  sketch, not a contract").
+- **DESIGN-0007** — receives the dated write-surface amendment (Phase 3).
+- **DESIGN-0008** — docz-api (unaffected consumer; its R2 surface is frozen,
+  not changed).
+- **IMPL-0013** — prior art: compiler-verified, behavior-preserving package
+  relocation + the `test/consumer/` external-module proof.
+- **sdk-booty-sh IMPL-0002** — Phase 0/W downstream gate; flips against the
+  `v1.0.0` tag. Its `doczwork` package additionally takes ownership of the
+  Plan/Phase model over the `docparse` primitives (Decisions Q3) — its
+  Phase W scope grows by that grouping code.

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -44,4 +44,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0011 | Status Set CLI Primitive | Completed | 2026-06-01 | Donald Gifford | [0011-status-set-cli-primitive.md](0011-status-set-cli-primitive.md) |
 | IMPL-0012 | Custom Document Type Support | Completed | 2026-06-18 | Donald Gifford | [0012-custom-document-type-support.md](0012-custom-document-type-support.md) |
 | IMPL-0013 | Promote parsing core to pkg/doczcore | Completed | 2026-06-30 | Donald Gifford | [0013-promote-parsing-core-to-pkgdoczcore.md](0013-promote-parsing-core-to-pkgdoczcore.md) |
+| IMPL-0014 | v1.0.0: the five-package pkg/doczcore public core | Draft | 2026-07-03 | Donald Gifford | [0014-v100-the-five-package-pkgdoczcore-public-core.md](0014-v100-the-five-package-pkgdoczcore-public-core.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md
+++ b/docs/investigation/0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md
@@ -1,0 +1,405 @@
+---
+id: INV-0006
+title: "Per-package core requirements: docz CLI vs docz-api, docz-site, sdk-booty-sh"
+status: Open
+author: Donald Gifford
+created: 2026-07-03
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0006: Per-package core requirements: docz CLI vs docz-api, docz-site, sdk-booty-sh
+
+**Status:** Open
+**Author:** Donald Gifford
+**Date:** 2026-07-03
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [Observation 1 — the consumer demand set, from primary sources](#observation-1--the-consumer-demand-set-from-primary-sources)
+  - [Observation 2 — per-package matrix: cmd/ requires vs consumers require](#observation-2--per-package-matrix-cmd-requires-vs-consumers-require)
+  - [Observation 3 — the packages nobody outside asks for are also the CLI-shaped ones](#observation-3--the-packages-nobody-outside-asks-for-are-also-the-cli-shaped-ones)
+  - [Observation 4 — Create is the only coupling between the write side and the template engine](#observation-4--create-is-the-only-coupling-between-the-write-side-and-the-template-engine)
+  - [Observation 5 — toc vs docparse: one concern splits cleanly in half](#observation-5--toc-vs-docparse-one-concern-splits-cleanly-in-half)
+  - [Observation 6 — dependency and embed audit: the four-package core is clean](#observation-6--dependency-and-embed-audit-the-four-package-core-is-clean)
+  - [Observation 7 — the wholesale-move failure mode has already happened once, in miniature](#observation-7--the-wholesale-move-failure-mode-has-already-happened-once-in-miniature)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [Open Questions](#open-questions)
+  - [1. Scope of the v1.0 public core?](#1-scope-of-the-v10-public-core)
+  - [2. Where does Create live at v1.0?](#2-where-does-create-live-at-v10)
+  - [3. One parser — does internal/toc delegate to docparse?](#3-one-parser--does-internaltoc-delegate-to-docparse)
+  - [4. The already-public CLI-shaped config helpers at v1.0?](#4-the-already-public-cli-shaped-config-helpers-at-v10)
+- [Decisions](#decisions)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+For every package the docz CLI is built from — `pkg/doczcore/{config,document}`
+(public since `v0.5.0`), `internal/{docwrite,template,index,toc,wiki}`, and the
+planned `pkg/doczcore/docparse` (`v0.6.0`) — exactly which exported surface does
+(a) `cmd/` require for the CLI to keep working as it does today, and (b) each
+external consumer (**docz-api**, **docz-site**, **sdk-booty-sh**) require?
+
+Concretely: does any external consumer need the embedded templates, README
+index generation, ToC splicing, or MkDocs wiki machinery — or is the
+demand-complete public core exactly the four parse/config/write-primitive
+packages (`config`, `document`, `docparse`, `docwrite`)?
+
+## Hypothesis
+
+External consumers need only the parsing/config core plus the two byte-level
+write primitives (`SetStatus`, `CheckTask`). Embedded templates, README index
+tables, ToC splicing, and MkDocs nav are **CLI presentation concerns** with
+zero external demand. If confirmed, ADR-0001's "move everything public" scope
+is wider than demand, and the idiomatic Go resolution is a smaller frozen
+`pkg/doczcore` core with the presentation packages remaining in `internal/` —
+the CLI goal ("works exactly as today") does not require promoting them.
+
+## Context
+
+ADR-0001 (Proposed) would end the per-consumer promotion drip by moving all
+five remaining `internal/` packages into `pkg/doczcore/*` and cutting `v1.0.0`
+as a semver freeze, with `cmd/` reduced to a thin shell. Its own "Demand
+mismatch" consequence flags that the known consumers never asked for
+`template`, `index`, or `wiki` — but that claim was stated from memory, not
+audited. This investigation grounds it symbol-by-symbol against the code and
+the three consumer requirement sources, so the ADR's scope (and its Open
+Question 3) can be resolved on evidence.
+
+**Triggered by:** ADR-0001; DESIGN-0008 (docz-api), DESIGN-0009 (docz-site),
+the sdk-booty-sh `v0.6.0` requirements handoff (`docz-v0.6.0-requirements.md`).
+
+## Approach
+
+1. Enumerate the exported surface of each package with `go doc -all` (the two
+   public packages plus all five `internal/` packages).
+2. Map `cmd/`'s actual per-symbol usage:
+   `grep -oE '(doctemplate|index|toc|wiki|docwrite)\.[A-Z]\w*' cmd/*.go`
+   (non-test files only), plus the import graph of `internal/*`.
+3. Extract each consumer's requirements from its primary source: DESIGN-0008
+   Requirements R1–R9 (including its exact-symbol table), DESIGN-0009's
+   decisions and non-goals, and `docz-v0.6.0-requirements.md` R1–R3.
+4. Diff the requirement sets per package; audit third-party dependencies and
+   `//go:embed` usage to check what each promotion would drag into a
+   consumer's build.
+
+## Environment
+
+| Component | Version / Value |
+|-----------|----------------|
+| docz tree | post-`v0.5.0`, commit `eb5c027` (branch `docs/adr-doczcore-v1-single-core`) |
+| Go | 1.26.4 |
+| Consumer sources | DESIGN-0008 (docz-api), DESIGN-0009 (docz-site, Draft), `docz-v0.6.0-requirements.md` (sdk-booty-sh handoff) |
+
+## Findings
+
+### Observation 1 — the consumer demand set, from primary sources
+
+**docz-api** (DESIGN-0008, R1–R9) is read-only and names its exact surface in
+the R2 table:
+
+- `doczcore/config`: `Load`, `(*Config).Validate`, `EnabledTypes`, `TypeDir`,
+  `ValidateType`; types `Config`, `TypeConfig` (fields `Enabled`, `Dir`,
+  `IDPrefix`, `IDWidth`, `Statuses`, `PluralLabel`, `Aliases`), `DocType`,
+  `Status`; sentinel `ErrUnknownType`.
+- `doczcore/document`: `ParseFrontmatter` (bytes-in is load-bearing — R3, the
+  no-checkout ingest path), `IsDoczFile`; types `Frontmatter`, `DocEntry`
+  (with `Content []byte` — R5); sentinel `ErrNoFrontmatter`. `ScanDocuments` /
+  `LoadFrontmatter` are nice-to-have only.
+- Explicitly **not** required: `docz export --json` (R8), any write API
+  (ingest is read-only, Decisions 4/5).
+
+**sdk-booty-sh** (`docz-v0.6.0-requirements.md`, R1–R3):
+
+- R1: `config.Load` with the same signature, **viper-free** (yaml.v3-only), so
+  importing `pkg/doczcore/...` compiles no viper tree.
+- R2: a new public `pkg/doczcore/docparse` — `Headings` (with 1-based `Line`,
+  which `internal/toc.Heading` lacks) and `ParsePlan` (phases + checkbox tasks
+  with `Checked` and `Line`).
+- R3: promote `docwrite` with `SetStatus` as-is and a new `CheckTask(path,
+  line)` — byte-preserving, LF-only. The write surface is deliberately
+  "status + checkbox only"; a general markdown editor is a stated non-goal.
+  **`Create` is not requested.**
+
+**docz-site** (DESIGN-0009) imports **no Go code at all**. It is a
+TypeScript thin client of docz-api: markdown is rendered client-side
+(markdown-it/remark + DOMPurify, Decision 3), the reader builds its own ToC
+from rendered headings and *strips* docz's `<!--toc:start-->` markers (OQ8a),
+and per-repo MkDocs wiki output is explicitly complementary, not consumed.
+
+Across all three consumers there is **zero demand** for `template`, `index`,
+`wiki`, or the ToC-splice half of `toc`.
+
+### Observation 2 — per-package matrix: `cmd/` requires vs consumers require
+
+| Package | `cmd/` requires (non-test call sites) | docz-api | sdk-booty-sh | docz-site | Verdict |
+|---|---|---|---|---|---|
+| `pkg/doczcore/config` | every command file: `Load`, `DefaultConfig`, `Validate`, `ValidateType`, `EnabledTypes`, `TypeDir`, `DocTypeNames`, `TypesHelp`, `DefaultNavTitles`, registry lookups, constants | R2 symbol list, R4 type resolution, R7 stable schema | R1 viper-free `Load` | — (via API) | **public** (already); `v0.6.0` removes viper |
+| `pkg/doczcore/document` | `list`/`status`/`update`: `ScanDocuments`, `LoadFrontmatter`, `IsDoczFile`, types | R2/R3/R5 (`ParseFrontmatter` bytes-in, `DocEntry.Content`) | baseline reads | — | **public** (already); stays read-only |
+| `internal/docwrite` | `create.go`: `Create`/`CreateOptions`; `status.go`: `SetStatus` + `ErrUnsupportedLineEndings` | none (read-only) | R3: `SetStatus` + `CheckTask` — **not `Create`** | — | **split**: `SetStatus`/`CheckTask` public (`v0.6.0`); `Create` has no external demand |
+| `internal/template` | `init` (`EmbeddedDoczYAML`, `ResolveIndexHeader`), `template` (`Resolve`), `update` (`ResolveIndexHeader`), `wiki` (`ResolveWikiIndex`, `RenderWikiIndex`, `WikiIndex*`); via `docwrite.Create` (`Resolve`, `Render`, `FilenameSlug`) | none | none | renders client-side | **internal** |
+| `internal/index` | `update.go`: `GenerateTable`, `UpdateReadme`, `DryRunReadme`, `UpdateOutcome` + `Action` enum | none | none | none | **internal** |
+| `internal/toc` | `update.go`: `FileInput`, `UpdateFiles`, markers; `wiki.go`: `BeginMarker`/`EndMarker` | none | heading **walk** only, generalized as `docparse` with `Line` | builds own ToC; strips markers | walk → **`docparse` (public)**; splice stays **internal** |
+| `internal/wiki` | `wiki.go` only: `ScanDocs`, `BuildNav`, `MergeNavOrder`, `NavToYAML`, `ReadMkDocs`/`WriteMkDocs`, `CreateMkDocs`, titles | none | none | complementary non-goal | **internal** |
+| `pkg/doczcore/docparse` (planned) | none today (CLI adoption is an explicit `v0.6.0` non-goal) | — | R2 (the driver) | — | **public** (new, `v0.6.0`) |
+
+The CLI's requirement set and the consumers' requirement set overlap **only**
+on `config`, `document`, `docwrite`'s status primitive, and (indirectly, once
+`toc`'s walker generalizes) `docparse`. Everything else `cmd/` needs is
+presentation: rendering templates, splicing marker blocks, formatting index
+tables, writing MkDocs nav.
+
+### Observation 3 — the packages nobody outside asks for are also the CLI-shaped ones
+
+The three unpromoted-by-demand packages are exactly the ones whose APIs encode
+CLI decisions, confirming ADR-0001's "CLI-shaped" concern:
+
+- `index.UpdateOutcome`'s `Action` enum (`ActionCreated`, `ActionNoMarkers`,
+  `ActionDryRunUpdated`, …) exists so `cmd/update.go` can choose user-facing
+  wording — six of its consts appear in `cmd/` conditionals.
+- `wiki`'s entire surface is MkDocs-specific (`CreateMkDocs`, `ReadMkDocs`,
+  `WriteMkDocs`, `NavToYAML`) and exists for `cmd/wiki.go` alone.
+- `template`'s embed accessors are barely used even in-repo:
+  `EmbeddedDocumentTemplate` and `EmbeddedWikiIndex` are called **only inside
+  the package itself** (tier-3 fallbacks of `Resolve`/`ResolveWikiIndex`);
+  the single direct `cmd/` embed call is `EmbeddedDoczYAML` in `init.go`.
+  The embedded FS is already an implementation detail — keeping it internal
+  costs nothing and avoids freezing template names/contents (ADR-0001 Corner
+  Case 1 dissolves rather than needing mitigation).
+
+Freezing these under semver would buy no consumer anything and would convert
+every future CLI UX change (new outcome wording, a non-MkDocs wiki backend, a
+template layout change) into a public-API question.
+
+### Observation 4 — `Create` is the only coupling between the write side and the template engine
+
+The single cross-`internal` edge in the tree is `docwrite → template`
+(`internal/docwrite/create.go` imports `internal/template` for `Resolve`,
+`Render`, `FilenameSlug`). Consequences:
+
+- The `v0.6.0` public `docwrite` (`SetStatus` + `CheckTask`) is
+  **stdlib-only** and byte-splice-shaped — it never touches the template
+  engine or the embed.
+- Promoting `Create` does **not** force `template` public: a public package
+  may import its own module's `internal/` packages (standard Go; the stdlib
+  does this pervasively). A public `docwrite.Create` keeps rendering via
+  `internal/template`; consumers compile the embed into their binaries but
+  cannot import it, and template names/contents stay out of the contract.
+  _(An earlier draft of this observation claimed the promotion "forces
+  `template` public" — that was wrong and is corrected here.)_
+- `CreateOptions`/`CreateResult` expose only `config` types, primitives, and
+  `time.Time` (verified against `create.go`); `internal/template` types
+  appear only in the function body, so the promoted signature leaks no
+  internal type.
+- What promoting `Create` **does** freeze is its observable behavior: the
+  `NNNN-slug.md` filename convention and the auto-increment scan — both
+  already de facto public via `document.DoczFilePattern`.
+
+### Observation 5 — `toc` vs `docparse`: one concern splits cleanly in half
+
+`internal/toc` is two concerns in one package:
+
+1. a **heading walk** (`ParseHeadings`, `Heading`, `AnchorSlug`) — this is
+   what sdk-booty-sh needs generalized, but with line numbers `toc.Heading`
+   doesn't carry, so `v0.6.0` R2 already specifies a richer `docparse.Heading`
+   rather than reusing it;
+2. a **ToC splice** (`GenerateToC`, `UpdateToC`, `UpdateFiles`, the
+   `BeginMarker`/`EndMarker` consts) — used by `cmd/update.go` and
+   `cmd/wiki.go`, and by nothing external. docz-site deliberately ignores the
+   marker blocks (DESIGN-0009 OQ8a strips them).
+
+So the public parser is `docparse`; the splice is CLI presentation. The only
+open point is whether `internal/toc` keeps its own walker or delegates to
+`docparse` (Open Question 3) — a private refactor either way, invisible to
+consumers and to CLI behavior.
+
+### Observation 6 — dependency and embed audit: the four-package core is clean
+
+- After `v0.6.0` R1 (viper removal), the demand-complete core
+  `pkg/doczcore/{config,document,docparse,docwrite}` depends on
+  `go.yaml.in/yaml/v3` (config, document) and stdlib **only**; `docparse` and
+  `docwrite` are stdlib-only by their specs.
+- The heavyweight bits stay behind: the one `//go:embed` lives in
+  `internal/template`; `internal/wiki` carries the only other `yaml.v3`
+  import; `index` and `toc` are stdlib-only but CLI-shaped.
+- A consumer importing `config`/`document`/`docparse` pulls no template
+  engine, no embed, no MkDocs machinery — the acceptance criterion
+  sdk-booty-sh already states for R1. (`docwrite`, once it includes `Create`,
+  compiles `internal/template` + the embed into the consumer's binary via
+  the legal public→internal import, but exposes none of it — see
+  Observation 4.)
+
+### Observation 7 — the wholesale-move failure mode has already happened once, in miniature
+
+The `v0.5.0` wholesale move of `config` carried some CLI-display helpers into
+the public, semver-governed surface: `TypesHelp()` (literally the `docz
+--help` body), `DefaultNavTitles()` (the wiki nav-title map), and
+`ResolveTypeAlias`. No consumer uses them; they are now frozen anyway. This is
+the exact failure mode ADR-0001's full promotion would repeat at 10× scale
+with `template`/`index`/`wiki` — evidence that "promote wholesale, review
+lightly" (ADR-0001 OQ3a) leaks CLI shapes into the contract. What to do with
+these three already-public symbols at v1.0 is Open Question 4.
+
+## Conclusion
+
+**Answer: Yes — the hypothesis is confirmed.**
+
+The demand-complete public core is exactly
+`pkg/doczcore/{config,document,docparse,docwrite}` — which is precisely where
+the tree stands after `v0.6.0` ships. Symbol-by-symbol, no external consumer
+needs the embedded templates, README index generation, ToC splicing, or MkDocs
+wiki machinery: docz-api's R2 table names only `config` + `document` symbols,
+sdk-booty-sh's slate adds only `docparse` + `docwrite`'s two byte-splice
+primitives, and docz-site imports no Go at all.
+
+The two goals in play — **the CLI works exactly as today** and **external
+services build on a shared core** — do not require promoting
+`template`/`index`/`toc`/`wiki`. The CLI is satisfied by `cmd/` + `internal/`
+presentation layered over the public core; the consumers are satisfied by the
+four-package core alone. ADR-0001's full-promotion scope is therefore wider
+than either goal demands, and its cost (freezing CLI-shaped APIs under semver)
+buys consistency, not capability. The idiomatic Go shape for this repo is the
+standard library-with-CLI layout: a deliberate, frozen `pkg/` surface plus an
+`internal/` that exists precisely to keep product-private code out of the
+contract.
+
+## Recommendation
+
+1. **Revise ADR-0001 before acceptance**: scope v1.0.0 as the freeze of the
+   four-package core; `template`, `index`, `toc` (splice), and `wiki` remain
+   `internal/`, and `docwrite` promotes **whole** (incl. `Create`,
+   implemented over `internal/template` — Observation 4). This resolves
+   ADR-0001 OQ3 (presentation stays internal; cohesion for `docwrite`),
+   makes OQ6 (embed publicity) moot, and reframes "thin `cmd/`" as "no *core
+   logic* in `cmd/`" rather than "no `internal/` at all.
+   _(Done 2026-07-03 — ADR-0001 revised; see its Decisions table.)_
+2. **Ship `v0.6.0` first, unchanged** (ADR-0001 OQ2a) — it already builds the
+   entire demand-complete core and unblocks sdk-booty-sh.
+3. **v1.0.0 becomes mostly a contract release**: the freeze declaration, API
+   doc hygiene and package docs over the four packages, expanding
+   `test/consumer/` to exercise the full v1.0 surface (incl. `docparse` +
+   `docwrite`), a stance on the already-public CLI-shaped config helpers
+   (Open Question 4), and the CLI-stability note.
+4. Resolve the Open Questions below, then fold the outcome into ADR-0001's
+   Decision section and cut the implementation plan.
+
+## Open Questions
+
+> Each question is numbered; option `a` is my recommendation, later letters
+> are alternatives, and the final letter is a free-form "other."
+
+### 1. Scope of the v1.0 public core?
+
+> **Resolved 2026-07-03: (a)** — via the promotion rule adopted in ADR-0001
+> Decision 1 ("public by default where demand exists, whole packages, named
+> exceptions"): `template`/`index`/`toc` splice/`wiki` have nothing external
+> demand requires, so they stay `internal/`.
+
+- **a. (Recommended)** **Four-package core**
+  `pkg/doczcore/{config,document,docparse,docwrite}`; `template`/`index`/
+  `toc`/`wiki` stay `internal/`. Demand-complete, zero unwanted semver
+  surface, CLI unchanged, idiomatic `internal/` use.
+- b. Full promotion per the ADR-0001 draft (all packages public, `cmd/`
+  imports only `pkg/doczcore/*`).
+- c. Full promotion with `template`/`index`/`wiki` documented as
+  experimental/exempt from the compatibility guarantee (ADR-0001 OQ3c).
+- d. Other.
+
+### 2. Where does `Create` live at v1.0?
+
+> **Resolved 2026-07-03: (b)** — package cohesion beats surface minimalism:
+> splitting `docwrite` to hide one function leaves a confusing twin-package
+> layout (public `docwrite` + an internal rump), and `Create` is plausibly
+> wanted by future consumers anyway. The cost cited against (b) in the
+> original draft was overstated — see Observation 4: the template engine
+> stays private behind the public→internal import.
+
+- a. **Stays internal.** When `SetStatus`/`CheckTask` move out in `v0.6.0`,
+  what's left of `internal/docwrite` is `Create` alone — keep it (optionally
+  renamed, e.g. `internal/doccreate`). Minimal surface, but a twin-package
+  layout every contributor must re-learn.
+- **b. (Chosen)** Promote `Create` into public `docwrite` at v1.0 — the whole
+  package promotes; the embed rides along in consumer *builds* via the legal
+  public→internal import, while `template`'s API, names, and contents stay
+  private (Observation 4).
+- c. Defer: promote `Create` only when a consumer asks (a normal additive
+  minor later, possibly with a template-injection seam instead of the embed).
+- d. Other.
+
+### 3. One parser — does `internal/toc` delegate to `docparse`?
+
+> **Resolved 2026-07-03: (a)** — delegate; and the export-lean ADR-0001
+> revision goes further: the splice itself promotes to `pkg/doczcore/toc`
+> (superseding this INV's demand-only "stays internal" verdict), with
+> `docparse` as the single public parser and `toc`'s own walker retired.
+
+- **a. (Recommended)** **Delegate.** Refactor `internal/toc` to consume
+  `docparse.Headings` for its walk (keeping the splice + markers internal),
+  during or immediately after the `v0.6.0` work so the two walkers never
+  drift on fence/slug behavior. Private refactor; invisible to consumers and
+  CLI output.
+- b. Keep two walkers (`toc` as-is) — allowed by the `v0.6.0` handoff
+  ("internal/toc can stay as-is or delegate"), but risks slug/fence
+  divergence between what the CLI splices and what consumers parse.
+- c. Other.
+
+### 4. The already-public CLI-shaped `config` helpers at v1.0?
+
+`TypesHelp()`, `DefaultNavTitles()`, and `ResolveTypeAlias` shipped with the
+`v0.5.0` wholesale move; no consumer uses them.
+
+> **Resolved 2026-07-03: (a)** — keep, consistent with the export-lean rule;
+> document them as CLI-support helpers in the package doc.
+
+- **a. (Recommended)** **Keep them** — they're small, already frozen, and
+  harmless; document them as CLI-support helpers in the package doc so the
+  core's intent stays legible.
+- b. Deprecate at v1.0 (`Deprecated:` markers) and remove at v2 — cleaner
+  long-term core, bookkeeping now.
+- c. Remove **before** v1.0 while still in `v0.x` (a `v0.7.0` with removals;
+  breaking-in-0.x is legal and no consumer is affected, but it contradicts
+  the additive-minor posture of `v0.6.0` and needs its own release).
+- d. Other.
+
+## Decisions
+
+Resolved by user review on 2026-07-03 and folded into ADR-0001's revised
+Decision section; all four questions are closed. Note: this INV's matrix
+records the **demand-only** verdicts; the adopted ADR-0001 scope goes further
+under the export-lean rule — `Create` and the `toc` splice promote too, and
+the entire former `v0.6.0` slate (viper-free `Load`, `docparse`, `CheckTask`)
+ships inside the single `v1.0.0` release with no intermediate tag.
+
+| #   | Question                        | Choice                          | Notes                                                                                              |
+| --- | ------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| 1   | v1.0 core scope                 | (a) as demand floor             | adopted scope adds `toc`: `pkg/doczcore/{config,document,docparse,docwrite,toc}`; `template`/`index`/`wiki` stay `internal/` |
+| 2   | `Create` at v1.0                | (b) promote `docwrite` whole    | cohesion over splitting; implemented over `internal/template`, embed stays private (Observation 4) |
+| 3   | `toc` → `docparse` delegation   | (a) delegate                    | and the splice promotes to public `pkg/doczcore/toc` (ADR-0001 export-lean); `toc`'s walker retires |
+| 4   | CLI-shaped `config` helpers     | (a) keep                        | documented as CLI-support helpers in the package doc                                               |
+
+## References
+
+- **ADR-0001** — pkg/doczcore as the single public core (the trigger; this
+  INV grounds its "Demand mismatch" consequence and OQ3/OQ4/OQ5/OQ6; revised
+  2026-07-03 with the promotion rule and Decisions this INV informed).
+- **DESIGN-0008** — docz-api: Requirements R1–R9, incl. the exact-symbol R2
+  table and R8 ("no `docz export --json`").
+- **DESIGN-0009** — docz-site: thin client of docz-api; client-side rendering
+  (Decision 3), own-ToC-from-rendered-headings (OQ8a), MkDocs wiki as
+  complementary non-goal.
+- **`docz-v0.6.0-requirements.md`** — sdk-booty-sh handoff: R1 viper-free
+  `config.Load`, R2 `docparse`, R3 `docwrite` promotion + `CheckTask`;
+  non-goals (no general editor, no new CLI commands).
+- **DESIGN-0007 / IMPL-0013** — the `v0.5.0` promotion (read-only stance,
+  minimal-surface goal, `internal/docwrite` split precedent).
+- **INV-0005** — Decision 7 (shared library over re-implemented parser).
+- Audit method: `go doc -all` per package;
+  `grep -oE '(doctemplate|index|toc|wiki|docwrite)\.[A-Z]\w*' cmd/*.go`
+  (non-test); `grep -rn 'docz/internal' internal/` (cross-internal edges);
+  `grep -rn 'yaml' internal/ pkg/` (dependency audit).

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -18,6 +18,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0003 | Init and Update Should Respect Config-Listed Types Only | Concluded | 2026-05-20 | Donald Gifford | [0003-init-and-update-should-respect-config-listed-types-only.md](0003-init-and-update-should-respect-config-listed-types-only.md) |
 | INV-0004 | v1 Release Plan: TUI, Markdown Preview, and CLI Parity | Open | 2026-05-22 | Donald Gifford | [0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md](0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md) |
 | INV-0005 | docz-api and docz-site: centralized cross-repo docz registry and viewer | Concluded | 2026-06-23 | Donald Gifford | [0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md](0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md) |
+| INV-0006 | Per-package core requirements: docz CLI vs docz-api, docz-site, sdk-booty-sh | Open | 2026-07-03 | Donald Gifford | [0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md](0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docz-v0.6.0-requirements.md
+++ b/docz-v0.6.0-requirements.md
@@ -1,0 +1,190 @@
+# docz v0.6.0 requirements — public surface for the sdk-booty-sh loop harness
+
+> **Handoff doc.** This file lives in `sdk-booty-sh` only as the requirements
+> capture; copy it into the docz repo and seed that repo's own docz documents
+> from it (likely one IMPL doc via `docz create impl`, plus a dated amendment to
+> DESIGN-0007). docz owns final API naming — everything below marked _proposed
+> shape_ is a consumer's sketch, not a contract on names.
+
+## Consumer context
+
+`sdk-booty-sh` is building a doc-driven agent loop harness (its DESIGN-0002 /
+IMPL-0002): an autonomous runner that uses a docz IMPL doc as its work source —
+parse phases and checkbox tasks, execute one task per iteration, check tasks
+off, and transition doc status, all programmatically and byte-preservingly.
+
+Its `pkg/loop/doczwork` package needs three things docz v0.5.0 doesn't expose: a
+body/task parser, a write API, and a viper-free config load. These close
+**upstream, once, in docz** (sdk-booty-sh INV-0008 Observation 9 decision)
+rather than as parsing workarounds in every consumer. **This slate blocks
+sdk-booty-sh IMPL-0002 Phase W** — the harness work source cannot start until
+`v0.6.0` tags (its decided policy is to wait for the tag; no `replace`
+directives).
+
+## Baseline: what v0.5.0 already provides
+
+Public (`pkg/doczcore`), all read-only:
+
+- `config.Load(configFile, repoRoot string) (Config, error)` — viper-backed
+- `Config.TypeDir(docType string) string`, `ValidateType`, `EnabledTypes`,
+  status/type definitions
+- `document.ParseFrontmatter(content []byte) (Frontmatter, error)`
+- `document.LoadFrontmatter(path string) (Frontmatter, []byte, error)`
+- `document.ScanDocuments(dir string) ([]DocEntry, error)` (sorted by ID;
+  invalid frontmatter silently skipped), `IsDoczFile`
+- `Frontmatter{ID, Title, Status config.Status, Author, Created}`;
+  `DocEntry{Frontmatter, Filename, Content}`
+
+Internal (not importable) but promotion-ready:
+
+- `internal/docwrite.SetStatus(path, newStatus string) (oldStatus string, err error)`
+  — byte-preserving frontmatter status rewrite, LF-only
+- `internal/toc.ParseHeadings(content string) []Heading` — dependency-free,
+  fence-aware, slug-generating heading walk (`Heading{Level, Text, Slug}` —
+  H2–H6, no line numbers today)
+
+viper appears in exactly one non-CLI path: `config.Load` →
+`mergeConfigFile(v *viper.Viper, ...)` / `loadFromFile`. All config structs
+already carry dual `mapstructure` + `yaml` tags, so removal is mechanical.
+
+## R1 — viper-free `config.Load`
+
+**Requirement:** same exported API, yaml-only implementation. Importing
+`pkg/doczcore/...` must not compile viper (or its transitive tree) into a
+consumer's build.
+
+- Keep the signature: `Load(configFile, repoRoot string) (Config, error)`.
+- Replace the viper merge path (`mergeConfigFile` / `loadFromFile`) with
+  `gopkg.in/yaml.v3` decoding onto the existing structs (the `yaml` tags are
+  already there).
+- Preserve current behavior: defaults fill, `.docz.yaml` discovery from
+  `repoRoot`, explicit `configFile` override, the types-replace-on-presence
+  logic, validation.
+- **Document the decode delta:** viper matches keys case-insensitively; yaml.v3
+  is case-sensitive. Call it out in the changelog / release notes (real-world
+  `.docz.yaml` files use lowercase keys, so breakage is unlikely but must be
+  stated). The existing parity baseline test should pin this.
+
+**Acceptance:** `go list -deps` of a scratch module importing only
+`pkg/doczcore/config` + `pkg/doczcore/document` contains no
+`github.com/spf13/viper` packages; existing config tests and the parity baseline
+stay green.
+
+## R2 — new `pkg/doczcore/docparse` (heading walk + plan model)
+
+**Requirement:** a public body parser producing (1) a heading walk with line
+positions and (2) an IMPL-style plan model — phases containing checkbox tasks
+with checked state and line numbers. Generalize `internal/toc.ParseHeadings`
+rather than writing a second walker; note the current `toc.Heading` has no line
+field, so `docparse` defines its own richer type (internal/toc can stay as-is or
+delegate).
+
+_Proposed shape:_
+
+```go
+package docparse
+
+type Heading struct {
+    Level int    // 2–6, H1 excluded (matches internal/toc behavior)
+    Text  string // inline markdown stripped
+    Slug  string // GitHub-compatible anchor
+    Line  int    // 1-based line of the heading
+}
+
+func Headings(content []byte) []Heading
+
+type Plan struct{ Phases []Phase }
+
+type Phase struct {
+    Title string // heading text, e.g. "Phase T: Toolbelt (pkg/tool)"
+    Line  int    // heading line
+    Tasks []Task
+}
+
+type Task struct {
+    Text    string // task text, checkbox marker stripped
+    Checked bool
+    Line    int // 1-based line of the "- [ ]" / "- [x]" item
+}
+
+func ParsePlan(content []byte) (Plan, error)
+```
+
+**Leniency rules** (the consumer's fixture corpus includes messy hand-written
+IMPL docs, not just template output):
+
+- A phase is any `###` heading (tolerate `**bold**` phase names — inline
+  markdown stripped, per the existing walker).
+- Tasks are **top-level** checkbox list items (`- [ ]` / `- [x]`, tolerant of
+  leading whitespace and `*` bullets) within the phase's span — under a
+  `#### Tasks` heading when one exists, otherwise anywhere in the phase.
+- Nested checkbox sub-items belong to their parent task (they are not
+  independent tasks).
+- Prose, tables, and non-checkbox lists between tasks are ignored, not errors.
+- Checkboxes inside code fences are ignored (the fence-awareness the toc walker
+  already has).
+- Line accounting is LF-only, matching `docwrite`'s contract, so `Task.Line`
+  feeds `CheckTask` directly with no re-scan.
+
+**Acceptance:** golden tests over template-conformant and messy fixtures;
+`Task.Line` values verified against the raw file bytes (a consumer will write
+through them).
+
+## R3 — promote `docwrite` + add `CheckTask`
+
+**Requirement:** promote `internal/docwrite` to `pkg/doczcore/docwrite` (keeping
+the CLI on the same implementation) and add a checkbox toggler under the same
+contract.
+
+- `SetStatus(path, newStatus string) (oldStatus string, err error)` — as-is, now
+  public. Byte-preserving single-splice rewrite, LF-only.
+- New:
+
+```go
+// CheckTask flips the unchecked task item on the given 1-based line to
+// checked ("[ ]" -> "[x]"), preserving every other byte. LF-only files.
+func CheckTask(path string, line int) error
+```
+
+- Semantics: the target line must be an unchecked checkbox list item (leading
+  whitespace + `-`/`*` bullet + `[ ]`); exactly the three marker bytes change.
+  Typed, distinguishable errors for: line out of range, line is not a task item,
+  task already checked. Same read-whole-file / single-splice / write-back
+  approach as `SetStatus`.
+- This revises DESIGN-0007's read-only-public stance for `pkg/doczcore` — add a
+  dated amendment note there (write surface = status + checkbox only, by design;
+  not a general editor).
+
+**Acceptance:** golden byte-diff tests — the on-disk diff after `CheckTask`
+touches exactly one line, byte-identical elsewhere; `SetStatus` behavior
+unchanged under its existing tests from the new import path.
+
+## Non-goals for v0.6.0
+
+- A general markdown AST or editing API — the write surface is status +
+  checkbox, deliberately.
+- Frontmatter editing beyond status.
+- CRLF support — LF-only stays the contract.
+- New CLI commands — the CLI may adopt `docparse`/`docwrite` internally, but
+  nothing here requires user-facing changes.
+
+## Release / compatibility
+
+- Additive minor release: `v0.6.0`. No changes to any v0.5.0 exported signature.
+- Suggested phasing for the docz IMPL doc: viper removal → `docparse` →
+  `docwrite` promotion + `CheckTask` → tag. (The three work items are
+  independent; any order works, the tag gates the consumer.)
+- Downstream gate to flip when done: sdk-booty-sh IMPL-0002 Phase 0 checks off
+  against the pushed tag.
+
+## References
+
+- sdk-booty-sh (consumer):
+  `docs/investigation/0008-doc-driven-agent-loop-harness-scoping-hcl-jobs-over-impl-docs.md`
+  Observation 9 (the promotion slate + import-cleanliness audit),
+  `docs/design/0002-doc-driven-agent-loop-harness-v1-design.md` (work-source
+  section — the exact call sequence `doczwork` makes),
+  `docs/impl/0002-doc-driven-agent-loop-harness-v1-implementation.md` Phase 0
+  (the milestone mirror of this slate).
+- docz: `docs/design/0007-docz-changes-to-support-docz-api-and-docz-site.md`
+  (read-only-public stance being revised by R3).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ nav:
     - Home: index.md
     - ADRs:
         - Overview: adr/README.md
+        - 'ADR-0001: pkg/doczcore as the single public core; cmd as a thin CLI shell (v1.0.0)': adr/0001-pkgdoczcore-as-the-single-public-core-cmd-as-a-thin-cli-shell.md
     - Design:
         - Overview: design/README.md
         - 'DESIGN-0001: docz CLI Tool': design/0001-docz-cli-design.md
@@ -27,6 +28,7 @@ nav:
         - 'IMPL-0011: Status Set CLI Primitive': impl/0011-status-set-cli-primitive.md
         - 'IMPL-0012: Custom Document Type Support': impl/0012-custom-document-type-support.md
         - 'IMPL-0013: Promote parsing core to pkg/doczcore': impl/0013-promote-parsing-core-to-pkgdoczcore.md
+        - 'IMPL-0014: v1.0.0: the five-package pkg/doczcore public core': impl/0014-v100-the-five-package-pkgdoczcore-public-core.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Wiki Init Template and Init Enabled Fix': investigation/0001-wiki-init-template-and-init-enabled-fix.md
@@ -34,6 +36,7 @@ nav:
         - 'INV-0003: Init and Update Should Respect Config-Listed Types Only': investigation/0003-init-and-update-should-respect-config-listed-types-only.md
         - 'INV-0004: v1 Release Plan: TUI, Markdown Preview, and CLI Parity': investigation/0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md
         - 'INV-0005: docz-api and docz-site: centralized cross-repo docz registry and viewer': investigation/0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md
+        - 'INV-0006: Per-package core requirements: docz CLI vs docz-api, docz-site, sdk-booty-sh': investigation/0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:


### PR DESCRIPTION
## Summary

Decision + planning slate for the **v1.0.0 five-package `pkg/doczcore` public core**. No code changes — three docz documents plus the regenerated indexes/nav, and the absorbed requirements handoff.

- **ADR-0001 (Accepted — all 7 open questions resolved):** freeze `pkg/doczcore/{config,document,docparse,docwrite,toc}` at `v1.0.0`; `template`/`index`/`wiki` stay `internal/`. Establishes the whole-package promotion rule (public by default where demand exists, cohesion over splitting, embedded templates as the named exception), the API design principles (bytes-in/values-out, no library-defined interfaces, path-writers only on consumer demand), and the sequencing call: **no separate v0.6.0** — the sdk-booty-sh slate ships inside v1.0.0 and sdk-booty-sh pins the `v1.0.0` tag. Post-1.0 compat: standard semver, roll-forward.
- **INV-0006:** the per-package demand audit (`cmd/` vs docz-api / docz-site / sdk-booty-sh, symbol-by-symbol) that grounds the ADR scope. Key facts: no external consumer needs `template`/`index`/`wiki`; public packages may import same-module `internal/` packages, so `docwrite.Create` promotes without exposing the embed.
- **IMPL-0014 (all 4 open questions resolved — ready to execute):** six phases — viper-free `config.Load` (viper leaves `go.mod` entirely; `cmd/` has no direct import), `docparse` **fact primitives** (`Headings` + `TaskItems` with byte-accurate lines; `ParsePlan` deliberately dropped — the plan/phase interpretation moves to sdk-booty-sh's `doczwork`), `docwrite` whole + `CheckTask`, `toc` promotion delegating to `docparse`, consumer-module proof over all five subpackages, then the `major`-labeled release PR.
- **`docz-v0.6.0-requirements.md`** (repo root): the sdk-booty-sh handoff these docs absorb, committed for the record; IMPL-0014 Phase 6 deletes it once the slate ships.

## Notes for review

- ADR-0001's Decisions table is the quick read: all seven questions locked 2026-07-03.
- IMPL-0014's Decisions table records `1a 2a 3d 4a` (sequential per-phase PRs; lenient yaml unknown-keys; ParsePlan dropped to the consumer; `UpdateFiles` goes public with `toc`).
- Downstream: sdk-booty-sh now waits on `v1.0.0` instead of `v0.6.0`, and its `doczwork` takes ownership of the Plan/Phase model over the `docparse` primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)