### PR TITLE
docs: flip IMPL-0014 to Completed (post-v1.0.0)

### DIFF
--- a/docs/impl/0014-v100-the-five-package-pkgdoczcore-public-core.md
+++ b/docs/impl/0014-v100-the-five-package-pkgdoczcore-public-core.md
@@ -1,7 +1,7 @@
 ---
 id: IMPL-0014
 title: "v1.0.0: the five-package pkg/doczcore public core"
-status: In Progress
+status: Completed
 author: Donald Gifford
 created: 2026-07-03
 ---
@@ -13,7 +13,6 @@ created: 2026-07-03
 **Status:** In Progress **Author:** Donald Gifford **Date:** 2026-07-03
 
 <!--toc:start-->
-
 - [Objective](#objective)
 - [Scope](#scope)
   - [In Scope](#in-scope)
@@ -362,7 +361,7 @@ consumer.
       case-sensitivity delta; note that v1 requires no module-path change.
 - [x] The release PR carries the **`major`** label; on merge, `pr-semver-bump` +
       goreleaser cut and publish **`v1.0.0`** (merge to `main` is human-gated).
-- [ ] Post-tag: flip this IMPL → Completed; notify sdk-booty-sh — its IMPL-0002
+- [x] Post-tag: flip this IMPL → Completed; notify sdk-booty-sh — its IMPL-0002
       Phase 0/W gate now pins `v1.0.0` (not `v0.6.0`).
 
 #### Success Criteria

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -44,5 +44,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0011 | Status Set CLI Primitive | Completed | 2026-06-01 | Donald Gifford | [0011-status-set-cli-primitive.md](0011-status-set-cli-primitive.md) |
 | IMPL-0012 | Custom Document Type Support | Completed | 2026-06-18 | Donald Gifford | [0012-custom-document-type-support.md](0012-custom-document-type-support.md) |
 | IMPL-0013 | Promote parsing core to pkg/doczcore | Completed | 2026-06-30 | Donald Gifford | [0013-promote-parsing-core-to-pkgdoczcore.md](0013-promote-parsing-core-to-pkgdoczcore.md) |
-| IMPL-0014 | v1.0.0: the five-package pkg/doczcore public core | In Progress | 2026-07-03 | Donald Gifford | [0014-v100-the-five-package-pkgdoczcore-public-core.md](0014-v100-the-five-package-pkgdoczcore-public-core.md) |
+| IMPL-0014 | v1.0.0: the five-package pkg/doczcore public core | Completed | 2026-07-03 | Donald Gifford | [0014-v100-the-five-package-pkgdoczcore-public-core.md](0014-v100-the-five-package-pkgdoczcore-public-core.md) |
 <!-- END DOCZ AUTO-GENERATED -->


### PR DESCRIPTION
Post-tag bookkeeping for IMPL-0014 (pattern of #67/#68):

- `v1.0.0` shipped 2026-07-05 via PR #71 (`major` label → pr-semver-bump + goreleaser; release published, not draft).
- Scratch-module verification passed: `go get github.com/donaldgifford/docz@v1.0.0` + imports of all five `pkg/doczcore` subpackages compile and run.
- IMPL-0014 status: In Progress → Completed (`docz status set`), index regenerated, final Phase 6 task checked off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)