### PR TITLE
docs: DESIGN-0010 Implemented, IMPL-0015 Completed (post-v1.1.0)

### DIFF
--- a/docs/design/0010-changelog-config-block-and-parsechangelog.md
+++ b/docs/design/0010-changelog-config-block-and-parsechangelog.md
@@ -1,7 +1,7 @@
 ---
 id: DESIGN-0010
 title: "Changelog config block and ParseChangelog"
-status: Draft
+status: Implemented
 author: Donald Gifford
 created: 2026-08-02
 ---
@@ -9,7 +9,7 @@ created: 2026-08-02
 
 # DESIGN 0010: Changelog config block and ParseChangelog
 
-**Status:** Draft
+**Status:** Implemented
 **Author:** Donald Gifford
 **Date:** 2026-08-02
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -41,5 +41,5 @@ docz create design "Your Design Title"
 | DESIGN-0007 | docz changes to support docz-api and docz-site | Implemented | 2026-06-23 | Donald Gifford | [0007-docz-changes-to-support-docz-api-and-docz-site.md](0007-docz-changes-to-support-docz-api-and-docz-site.md) |
 | DESIGN-0008 | docz-api: cross-repo docz registry and ingestion service | Approved | 2026-06-23 | Donald Gifford | [0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md](0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md) |
 | DESIGN-0009 | docz-site: cross-repo docz viewer and search UI | Draft | 2026-06-23 | Donald Gifford | [0009-docz-site-cross-repo-docz-viewer-and-search-ui.md](0009-docz-site-cross-repo-docz-viewer-and-search-ui.md) |
-| DESIGN-0010 | Changelog config block and ParseChangelog | Draft | 2026-08-02 | Donald Gifford | [0010-changelog-config-block-and-parsechangelog.md](0010-changelog-config-block-and-parsechangelog.md) |
+| DESIGN-0010 | Changelog config block and ParseChangelog | Implemented | 2026-08-02 | Donald Gifford | [0010-changelog-config-block-and-parsechangelog.md](0010-changelog-config-block-and-parsechangelog.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0015-v110-changelog-config-block-and-parsechangelog.md
+++ b/docs/impl/0015-v110-changelog-config-block-and-parsechangelog.md
@@ -1,7 +1,7 @@
 ---
 id: IMPL-0015
 title: "v1.1.0 — changelog config block and ParseChangelog"
-status: Draft
+status: Completed
 author: Donald Gifford
 created: 2026-08-02
 ---
@@ -9,7 +9,7 @@ created: 2026-08-02
 
 # IMPL 0015: v1.1.0 — changelog config block and ParseChangelog
 
-**Status:** Draft
+**Status:** Completed
 **Author:** Donald Gifford
 **Date:** 2026-08-02
 
@@ -40,6 +40,7 @@ created: 2026-08-02
   - [3. ParseChangelog return shape?](#3-parsechangelog-return-shape)
 - [Decisions](#decisions)
 - [Notes for review](#notes-for-review)
+- [Outcome](#outcome)
 - [References](#references)
 <!--toc:end-->
 
@@ -234,7 +235,7 @@ outside the module before it freezes.
       the design doc, this IMPL, and all four phases, labeled **`minor`**
       (Decision 1); on merge, `pr-semver-bump` + goreleaser cut `v1.1.0`
       (merge to `main` is human-gated).
-- [ ] Post-tag: scratch-module `go get github.com/donaldgifford/docz@v1.1.0`
+- [x] Post-tag: scratch-module `go get github.com/donaldgifford/docz@v1.1.0`
       exercising `Config.Changelog` + `ParseChangelog`; flip DESIGN-0010 →
       Implemented and this IMPL → Completed (`dont-release` PR, the #67/#68
       pattern); notify docz-api that the pin bump + contract clause R6 are
@@ -427,6 +428,26 @@ All three open questions resolved **(a)** on 2026-08-02.
   deliberately does not reject them; docz-api must escape the segments
   when it splices the path into a contents URL rather than relying on
   docz's validator to have made it URL-safe.
+
+## Outcome
+
+**`v1.1.0` shipped 2026-08-03.** PR #78 (`minor`) merged to `main` →
+`pr-semver-bump` + goreleaser tagged and published the release (previous
+tag `v1.0.0`).
+
+Post-tag verification, run against the published tag rather than a local
+`replace`: a scratch module resolved `go get
+github.com/donaldgifford/docz@v1.1.0` from the proxy and exercised the
+whole R6 surface — `config.Load` decoding an enabled block and
+normalizing `./CHANGELOG.md` to `CHANGELOG.md`, `Validate` rejecting
+`../../etc/passwd` matchable via `errors.Is(err,
+config.ErrInvalidChangelogFile)`, `config.DefaultChangelogFile`, and
+`document.ParseChangelog` returning both versions with the unreleased
+section flagged, a wrapped continuation folded into its item, and
+`ErrNoVersions` with a nil result on a version-less document.
+
+DESIGN-0010 → Implemented, IMPL-0015 → Completed. docz-api's pin bump and
+contract clause R6 are unblocked.
 
 ## References
 

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -45,5 +45,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0012 | Custom Document Type Support | Completed | 2026-06-18 | Donald Gifford | [0012-custom-document-type-support.md](0012-custom-document-type-support.md) |
 | IMPL-0013 | Promote parsing core to pkg/doczcore | Completed | 2026-06-30 | Donald Gifford | [0013-promote-parsing-core-to-pkgdoczcore.md](0013-promote-parsing-core-to-pkgdoczcore.md) |
 | IMPL-0014 | v1.0.0: the five-package pkg/doczcore public core | Completed | 2026-07-03 | Donald Gifford | [0014-v100-the-five-package-pkgdoczcore-public-core.md](0014-v100-the-five-package-pkgdoczcore-public-core.md) |
-| IMPL-0015 | v1.1.0 — changelog config block and ParseChangelog | Draft | 2026-08-02 | Donald Gifford | [0015-v110-changelog-config-block-and-parsechangelog.md](0015-v110-changelog-config-block-and-parsechangelog.md) |
+| IMPL-0015 | v1.1.0 — changelog config block and ParseChangelog | Completed | 2026-08-02 | Donald Gifford | [0015-v110-changelog-config-block-and-parsechangelog.md](0015-v110-changelog-config-block-and-parsechangelog.md) |
 <!-- END DOCZ AUTO-GENERATED -->


### PR DESCRIPTION
## Summary

Post-tag status flips following the `v1.1.0` release (#78), matching the #67/#68 pattern. Documentation only — labeled `dont-release`.

- **DESIGN-0010** → Implemented
- **IMPL-0015** → Completed (last Phase 4 task checked; all tasks across all four phases now complete)
- README index tables regenerated via `docz update`
- IMPL-0015 gains an **Outcome** section recording the release and its verification

## Verification against the published tag

Rather than a local `replace`, a scratch module resolved `go get github.com/donaldgifford/docz@v1.1.0` from the module proxy and exercised the full contract-clause-R6 surface:

```
Changelog.Enabled = true
Changelog.File    = "CHANGELOG.md" (leading ./ normalized)
DefaultChangelogFile = "CHANGELOG.md"
traversal rejected via errors.Is(ErrInvalidChangelogFile) = true
versions = 2, preamble = 55 bytes
  unreleased   unreleased=true  date=""         groups=1
      [Bug Fixes] "*(chart)* Scope the Service selector ([#12](...))"
  0.4.2        unreleased=false date="2026-07-23" groups=1
      [Miscellaneous Tasks] "*(release)* Cut v0.4.2\n  with a wrapped continuation line"
ErrNoVersions = true, nil result = true
```

## Downstream

docz-api's pin bump to `v1.1.0` and contract clause R6 are unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)