### PR TITLE
fix(template,config): prefix-qualified H1s, PLAN disabled by default, DESIGN-0011/INV-0007

### DIFF
--- a/.docz.example.yaml
+++ b/.docz.example.yaml
@@ -1,0 +1,123 @@
+---
+docs_dir: docs
+
+types:
+  rfc:
+    enabled: true
+    dir: rfc
+    template: ""
+    id_prefix: "RFC"
+    id_width: 4
+    statuses:
+      - Draft
+      - Proposed
+      - Accepted
+      - Rejected
+      - Superseded
+    status_field: "status"
+
+  adr:
+    enabled: true
+    dir: adr
+    template: ""
+    id_prefix: "ADR"
+    id_width: 4
+    statuses:
+      - Proposed
+      - Accepted
+      - Deprecated
+      - Superseded
+    status_field: "status"
+
+  design:
+    enabled: true
+    dir: design
+    template: ""
+    id_prefix: "DESIGN"
+    id_width: 4
+    statuses:
+      - Draft
+      - In Review
+      - Approved
+      - Implemented
+      - Abandoned
+    status_field: "status"
+
+  impl:
+    enabled: true
+    dir: impl
+    template: ""
+    id_prefix: "IMPL"
+    id_width: 4
+    statuses:
+      - Draft
+      - In Progress
+      - Completed
+      - Paused
+      - Cancelled
+    status_field: "status"
+
+  plan:
+    enabled: false # PLAN ships disabled; set true to use it
+    dir: plan
+    template: ""
+    id_prefix: "PLAN"
+    id_width: 4
+    statuses:
+      - Draft
+      - In Progress
+      - Completed
+      - Cancelled
+    status_field: "status"
+
+  investigation:
+    enabled: true
+    dir: investigation
+    template: ""
+    id_prefix: "INV"
+    id_width: 4
+    statuses:
+      - Open
+      - In Progress
+      - Concluded
+      - Inconclusive
+      - Abandoned
+    status_field: "status"
+
+index:
+  auto_update: true
+  preserve_header: true
+
+author:
+  from_git: true
+  default: ""
+
+wiki:
+  auto_update: true
+  mkdocs_path: mkdocs.yml
+  exclude:
+    - templates
+    - examples
+
+# PROPOSED — not yet implemented. See DESIGN-0011; ships in docz v1.2.0.
+# docz ignores unknown keys, so this block is inert until then.
+api:
+  enabled: true
+
+  # The repo's landing page on docz-site.
+  # Optional; defaults to <docs_dir>/index.md.
+  landing_page: "docs/index.md"
+
+  # Path prefixes under docs_dir that are never published.
+  # docs_dir/templates/ is always excluded and need not be listed.
+  exclude: []
+
+  # Markdown OUTSIDE docs_dir. Every .md under docs_dir is already consumed:
+  #   docs/index.md            -> <site>/<owner>/<repo>
+  #   docs/impl/README.md      -> <site>/<owner>/<repo>/impl
+  #   docs/impl/0015-foo.md    -> <site>/<owner>/<repo>/impl/IMPL-0015
+  #   docs/examples/README.md  -> <site>/<owner>/<repo>/examples
+  # so only repo-root files need listing here:
+  additional_docs:
+    - "CONTRIBUTING.md"
+    - "DEVELOPMENT.md"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ README index tables up to date.
 
 ## Features
 
-- **Six built-in document types:** RFC, ADR, DESIGN, IMPL, PLAN, INV
+- **Six built-in document types:** RFC, ADR, DESIGN, IMPL, PLAN, INV (PLAN ships disabled — enable it in `.docz.yaml`)
 - **Custom document types:** define your own types in `.docz.yaml` — own prefix, statuses, aliases, and templates — invoked by name, alias, or `id_prefix`
 - **Auto-incremented IDs:** documents are numbered sequentially within their type directory
 - **YAML frontmatter:** every document carries structured metadata (id, title, status, author, created)
@@ -47,11 +47,11 @@ This creates:
 - `docs/adr/README.md`
 - `docs/design/README.md`
 - `docs/impl/README.md`
-- `docs/plan/README.md`
 - `docs/investigation/README.md`
 
 Types with `enabled: false` in `.docz.yaml` are skipped — no directory or
-README is created for them.
+README is created for them. **PLAN is disabled by default**, which is why
+`docs/plan/` is absent above; set `types.plan.enabled: true` to scaffold it.
 
 ### Create your first document
 
@@ -197,6 +197,9 @@ Mid-level planning documents that sit between an RFC (what and why) and an IMPL
 (step-by-step execution). Use a plan to work out the approach and component
 breakdown before writing detailed tasks.
 
+**Disabled by default** — most repos fill this slot with a DESIGN plus an IMPL.
+Set `types.plan.enabled: true` in `.docz.yaml` to turn it on.
+
 ```
 docs/plan/
 └── 0001-telemetry-pipeline-approach.md
@@ -337,7 +340,7 @@ types:
       - Paused
       - Cancelled
   plan:
-    enabled: true
+    enabled: false # PLAN ships disabled; set true to use it
     dir: plan
     id_prefix: PLAN
     id_width: 4

--- a/cmd/inv0003_test.go
+++ b/cmd/inv0003_test.go
@@ -133,15 +133,21 @@ func TestINV0003_RFCOnlyConfig_UpdateTouchesOnlyRFC(t *testing.T) {
 	}
 }
 
-func TestINV0003_NoConfig_InitScaffoldsAllSix(t *testing.T) {
+func TestINV0003_NoConfig_InitScaffoldsEnabledDefaults(t *testing.T) {
 	dir := setupINV0003Test(t, "")
 
 	runRoot(t, "init")
 
-	for _, typeName := range []string{"rfc", "adr", "design", "impl", "plan", "investigation"} {
+	for _, typeName := range []string{"rfc", "adr", "design", "impl", "investigation"} {
 		if _, err := os.Stat(filepath.Join(dir, "docs", typeName)); err != nil {
 			t.Errorf("docs/%s should be scaffolded in green-field init: %v", typeName, err)
 		}
+	}
+
+	// plan ships disabled, so a green-field init must not create it —
+	// the same rule INV-0003 established for any disabled type.
+	if _, err := os.Stat(filepath.Join(dir, "docs", "plan")); !os.IsNotExist(err) {
+		t.Errorf("docs/plan should not be scaffolded: plan is disabled by default (err = %v)", err)
 	}
 }
 

--- a/docs/design/0001-docz-cli-design.md
+++ b/docs/design/0001-docz-cli-design.md
@@ -283,11 +283,12 @@ author: {{ .Author }}
 created: {{ .Date }}
 ---
 
-# RFC {{ .Number }}: {{ .Title }}
+<!-- markdownlint-disable-file MD025 MD041 -->
 
-**Status:** {{ .Status }}
-**Author:** {{ .Author }}
-**Date:** {{ .Date }}
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
+
+<!--toc:start-->
+<!--toc:end-->
 
 ## Summary
 
@@ -295,32 +296,24 @@ created: {{ .Date }}
 
 ## Problem Statement
 
-<!-- What problem does this RFC address? Include evidence and impact. -->
+<!-- What problem does this RFC address? Include supporting data, evidence and impact. -->
+
+### Supporting Data
+
+<!-- Data gathered that support the proposed solution. -->
 
 ## Proposed Solution
 
 <!-- High-level description of the proposed approach -->
 
-## Design
-
-<!-- Detailed design including architecture, data flow, APIs, etc. -->
-
 ## Alternatives Considered
 
 <!-- What other approaches were evaluated and why were they rejected? -->
 
-## Implementation Phases
-
-<!-- Break the implementation into phases/milestones -->
-
-### Phase 1: ...
-
-### Phase 2: ...
-
 ## Risks and Mitigations
 
 | Risk | Impact | Likelihood | Mitigation |
-|------|--------|------------|------------|
+| ---- | ------ | ---------- | ---------- |
 |      |        |            |            |
 
 ## Success Criteria
@@ -343,11 +336,16 @@ author: {{ .Author }}
 created: {{ .Date }}
 ---
 
-# {{ .Number }}. {{ .Title }}
+<!-- markdownlint-disable-file MD025 MD041 -->
 
-## Status
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
 
-{{ .Status }}
+<!--toc:start-->
+<!--toc:end-->
+
+## Summary
+
+<!-- Brief 2-3 sentence summary of the proposal -->
 
 ## Context
 
@@ -356,6 +354,10 @@ created: {{ .Date }}
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
+
+### Supporting Data
+
+<!-- Data gathered that support the proposed solution. -->
 
 ## Consequences
 
@@ -393,11 +395,12 @@ author: {{ .Author }}
 created: {{ .Date }}
 ---
 
-# DESIGN {{ .Number }}: {{ .Title }}
+<!-- markdownlint-disable-file MD025 MD041 -->
 
-**Status:** {{ .Status }}
-**Author:** {{ .Author }}
-**Date:** {{ .Date }}
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
+
+<!--toc:start-->
+<!--toc:end-->
 
 ## Overview
 
@@ -458,21 +461,20 @@ author: {{ .Author }}
 created: {{ .Date }}
 ---
 
-# IMPL {{ .Number }}: {{ .Title }}
+<!-- markdownlint-disable-file MD025 MD041 -->
 
-**Status:** {{ .Status }}
-**Author:** {{ .Author }}
-**Date:** {{ .Date }}
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
+
+<!--toc:start-->
+<!--toc:end-->
 
 ## Objective
 
-<!-- What is being implemented? Link to the RFC/DESIGN it implements. -->
+<!-- What is being implemented? Link to the RFC/DESIGN/PLAN it implements. -->
 
-**Implements:** <!-- RFC-XXXX / DESIGN-XXXX -->
+**Implements:** <!-- RFC-XXXX / DESIGN-XXXX / PLAN-XXXX -->
 
 ## Scope
-
-<!-- Specific scope of this implementation plan -->
 
 ### In Scope
 
@@ -482,33 +484,81 @@ created: {{ .Date }}
 
 -
 
-## Implementation Steps
+## Implementation Phases
 
-### Step 1: ...
+Each phase builds on the previous one. A phase is complete when all its tasks
+are checked off and its success criteria are met.
+
+---
+
+### Phase 1: <!-- Foundation / Setup / Core -->
+
+<!-- Describe what this phase establishes. Focus on the internal
+     building blocks that later phases depend on. -->
+
+#### Tasks
 
 - [ ] Task description
 - [ ] Task description
+- [ ] Write unit tests for ...
 
-### Step 2: ...
+#### Success Criteria
+
+- `go build ./...` succeeds with no errors
+- ...
+
+---
+
+### Phase 2: <!-- Core Feature / Primary Commands -->
+
+<!-- Describe what this phase delivers to users. -->
+
+#### Tasks
 
 - [ ] Task description
+- [ ] Task description
+- [ ] Write integration tests for ...
+
+#### Success Criteria
+
+- Feature X works end-to-end
+- ...
+
+---
+
+### Phase 3: <!-- Polish / Edge Cases / CI Readiness -->
+
+<!-- Harden, test, and prepare for release. -->
+
+#### Tasks
+
+- [ ] Audit error messages for consistency
+- [ ] Ensure `make ci` passes
+- [ ] Review test coverage (target: >80%)
+- [ ] Clean up any TODO/FIXME comments
+
+#### Success Criteria
+
+- `make ci` passes with zero errors
+- Test coverage >80% for all packages
+- All error paths produce clear, actionable messages
+
+---
 
 ## File Changes
 
 <!-- Key files that will be created or modified -->
 
 | File | Action | Description |
-|------|--------|-------------|
-|      |        |             |
+| ---- | ------ | ----------- |
+|      | Create |             |
+|      | Modify |             |
 
 ## Testing Plan
 
-- [ ] Unit tests for ...
-- [ ] Integration tests for ...
-
-## Rollback Plan
-
-<!-- How to revert if something goes wrong -->
+- [ ] Unit tests for all exported functions
+- [ ] Integration tests using `t.TempDir()` for filesystem operations
+- [ ] Table-driven tests for functions with multiple input variations
 
 ## Dependencies
 
@@ -516,7 +566,7 @@ created: {{ .Date }}
 
 ## References
 
-<!-- Links to related RFCs, ADRs, designs, issues -->
+<!-- Links to related RFCs, ADRs, designs, plans, issues -->
 ```
 
 ## Index Generation

--- a/docs/design/0011-api-config-block-index-page-and-additionaldocs-for-docz-api-and.md
+++ b/docs/design/0011-api-config-block-index-page-and-additionaldocs-for-docz-api-and.md
@@ -1,0 +1,571 @@
+---
+id: DESIGN-0011
+title: "api config block: index page and additional_docs for docz-api and docz-site"
+status: Draft
+author: Donald Gifford
+created: 2026-08-10
+---
+
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN-0011: api config block: index page and additional_docs for docz-api and docz-site
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [The api block](#the-api-block)
+  - [The consumption rule](#the-consumption-rule)
+  - [Config types](#config-types)
+  - [Normalization](#normalization)
+  - [Validation](#validation)
+  - [Titles for frontmatter-less documents](#titles-for-frontmatter-less-documents)
+  - [Route mapping (non-normative)](#route-mapping-non-normative)
+- [API / Interface Changes](#api--interface-changes)
+  - [Downstream contract (what docz-api pins as R10)](#downstream-contract-what-docz-api-pins-as-r10)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+  - [10. Should images and other assets be consumed?](#10-should-images-and-other-assets-be-consumed)
+- [Decisions](#decisions)
+  - [Revision history](#revision-history)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+Add an opt-in `api:` block to `.docz.yaml` that declares what docz-api ingests
+and docz-site renders beyond the docz documents themselves: a **landing page**
+for the repo, an **exclusion list**, and **`additional_docs`** — markdown that
+lives outside `docs_dir` entirely, like `CONTRIBUTING.md`.
+
+The governing rule is that **the URL path mirrors the `docs_dir` path**. Every
+`.md` under `docs_dir` is consumable: a directory's `README.md` is that
+directory's page, documents inside a type directory keep their id-addressed
+route, and everything else is addressed at its `docs_dir`-relative path.
+`additional_docs` is the escape hatch for the files that convention places
+outside `docs_dir`.
+
+The block is inert to the docz CLI: it changes no command's behavior. Its job
+is to be a **validated, semver-governed declaration** that consumers read.
+INV-0007 audited what this costs docz internally: the config half is routine,
+but the feature also needs one genuine addition to the frozen public surface —
+a bytes-in title extractor for documents that have no frontmatter.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Make everything a repo puts under `docs_dir` reachable on docz-site, without
+  the repo enumerating it.
+- Let a repo surface markdown that lives outside `docs_dir` by convention
+  (`CONTRIBUTING.md`, `DEVELOPMENT.md`).
+- Let a repo declare its landing page and exclude what should not be published.
+- Validate the declared paths at load time with the same rigor as
+  `changelog.file` — these are paths a consumer fetches from a git tree.
+- Preserve the **dormancy guarantee** (DESIGN-0010 Decision 7): a repo can add
+  the block before any consumer understands it, and nothing breaks.
+- Give consumers a supported way to derive a display title for a document with
+  no frontmatter, so the H1 rule is defined once in docz rather than
+  reimplemented per consumer.
+
+### Non-Goals
+
+- **No CLI behavior change.** `docz create`/`update`/`list`/`wiki` ignore the
+  block entirely. It is declaration, not instruction.
+- **No route construction in docz.** docz stores and validates configuration;
+  building `https://docz.fartlab.dev/...` is docz-site's concern (ADR-0001:
+  facts, not interpretation).
+- **No fetching, globbing, or filesystem walking** in `pkg/doczcore`. Consumers
+  resolve paths against whatever tree they have.
+- **No new document model.** Path-addressed documents are not docz documents:
+  no id, no type, no status, no ToC injection, no index-table row.
+- **No asset pipeline.** Images and other binaries are out of scope for this
+  design (Decision 10).
+- **Not a replacement for `wiki:`.** MkDocs nav generation stays as it is.
+
+## Background
+
+Three things converge here.
+
+**docz-api ingests without a checkout** (DESIGN-0008 Decision 1). It calls the
+GitHub Git Trees API with `recursive=1`, filters to `.docz.yaml` plus blobs
+under `docs_dir/<type.dir>/`, fetches those blobs as bytes, and parses them
+with `doczcfg.Load` + `doczdoc.ParseFrontmatter`. Every file it knows about
+today is inside a type directory and has frontmatter. `docs/examples/README.md`
+is outside that filter — `examples` is not a type dir — and `CONTRIBUTING.md` is
+not even under `docs_dir` (INV-0007 F5).
+
+**docz-site already mirrors the docz tree** (DESIGN-0009):
+
+```text
+/:owner/:repo                   Repo detail
+/:owner/:repo/:type             List of documents of one type
+/:owner/:repo/:type/:docId      Single document reader
+```
+
+That is the same shape as `docs/`, `docs/rfc/`, `docs/rfc/0001-x.md`. This
+design makes that correspondence the explicit rule rather than a coincidence,
+and extends it to directories under `docs_dir` that are not types.
+
+**`changelog:` is the precedent.** DESIGN-0010 / IMPL-0015 added an opt-in
+block carrying a repo-relative path, normalized it on both `Load` paths,
+validated it only when enabled, and emitted it default-off from `docz init`.
+`additional_docs` is that same thing pluralized. The precedent also supplies
+the path-hardening rules — control characters, backslashes, absolute paths,
+Windows volume names, `~`, trailing `/`, `..` and non-canonical segments —
+which were expensive to get right and must not be reinvented (INV-0007 F3).
+
+## Detailed Design
+
+### The api block
+
+```yaml
+api:
+  enabled: true
+
+  # The repo's landing page. Optional; defaults to <docs_dir>/index.md.
+  landing_page: "docs/index.md"
+
+  # Path prefixes under docs_dir that are never published.
+  # docs_dir/templates/ is always excluded and need not be listed.
+  exclude:
+    - scratch
+
+  # Markdown OUTSIDE docs_dir. Anything inside docs_dir is already consumed.
+  additional_docs:
+    - "CONTRIBUTING.md"
+    - "DEVELOPMENT.md"
+```
+
+Note what is *absent*: `docs/examples/README.md` no longer needs listing. It is
+under `docs_dir`, so it is consumed automatically and serves as the page for
+`examples/`.
+
+Leading `./` is accepted and stripped during normalization, matching
+`normalizeChangelog`, so the `./CONTRIBUTING.md` form stays valid.
+
+### The consumption rule
+
+When `api.enabled` is true:
+
+1. **Markdown only.** `*.md` under `docs_dir`. Nothing else — this repo's
+   `docs/examples/` holds one `.md` and twelve `.sh` files, and shell scripts
+   are not documents. Assets are Decision 10.
+2. **A directory's index file is that directory's page.** `docs/index.md` is
+   the repo root; `<dir>/README.md` is the page for `<dir>`. This holds
+   uniformly, inside type directories and outside them:
+   `docs/impl/README.md` → `/:owner/:repo/impl`,
+   `docs/examples/README.md` → `/:owner/:repo/examples`. The docz-generated
+   index table therefore *is* the type page's body, which is how docz-site
+   already serves it.
+3. **Type directories are otherwise reserved for docz documents.** A file under
+   an enabled type's `dir` that is not its `README.md` must have frontmatter
+   and match `IsDoczFile`; it is addressed `/:owner/:repo/:type/:docId` as
+   today. A stray non-conforming `.md` there is skipped and reported rather
+   than path-addressed — `/impl/notes.md` would be indistinguishable from
+   `/impl/:docId`, and a type directory is a namespace docz itself manages, so
+   a non-conforming file there is far more likely a mistake than an intent.
+4. **Everything else under `docs_dir`** — minus exclusions, minus the index
+   files consumed by (2) — is **path-addressed at its path relative to
+   `docs_dir`**. `docs/examples/example1.md` → `examples/example1.md`.
+5. **`docs_dir/templates/` is always excluded.** It holds
+   `<docs_dir>/templates/<type>.md` and `index_<type>.md` override files —
+   docz's own machinery, never documents. Excluding it unconditionally means
+   `api.exclude` defaults to empty and a user who sets it does not silently
+   lose the `templates` protection (the footgun `wiki.exclude` has, where
+   setting the key replaces the default list wholesale).
+6. **`additional_docs` are files outside `docs_dir`**, each path-addressed at
+   its repo-relative path. An entry under `docs_dir` is a validation error —
+   it is already consumed by (1)–(4), and listing it would produce two records
+   for one file.
+
+### Config types
+
+```go
+// APIConfig declares what docz-api and docz-site surface for this repo.
+type APIConfig struct {
+    Enabled        bool     `yaml:"enabled"`
+    LandingPage    string   `yaml:"landing_page"`
+    Exclude        []string `yaml:"exclude"`
+    AdditionalDocs []string `yaml:"additional_docs"`
+}
+```
+
+`yaml` tags only, no `mapstructure` — the siblings' `mapstructure` tags are
+vestigial post-viper, and IMPL-0015 set this precedent for `ChangelogConfig`.
+
+There is deliberately **no nested index struct**. Naming a landing page is
+enabling it, so a separate boolean is redundant, and a nested `api.index` would
+collide with the top-level `index:` block that governs README table generation.
+
+`Config` gains one field:
+
+```go
+type Config struct {
+    // ...
+    Changelog ChangelogConfig `yaml:"changelog"`
+    API       APIConfig       `yaml:"api"`
+}
+```
+
+`DefaultConfig()` remains the sole source of defaults: `Enabled: false`,
+`LandingPage: ""`, `Exclude: nil`, `AdditionalDocs: nil`. The block is dormant
+by default.
+
+### Normalization
+
+`normalizeAPI(&cfg)` runs on both `Load` paths, immediately after
+`normalizeChangelog` (which follows `fillTypeFieldDefaults`). It:
+
+1. Backfills `api.landing_page` when empty and `api.enabled` is true —
+   resolved as `<docs_dir>/index.md`, so it tracks a non-default `docs_dir`.
+2. Strips leading `./` from `landing_page`, every `exclude` entry, and every
+   `additional_docs` entry.
+3. Leaves everything else alone. As with `changelog.file`, it deliberately does
+   **not** call `filepath.Clean` — that would silently resolve the `..` that
+   validation must still be able to see and reject.
+
+Normalization never rejects. *Load normalizes, Validate judges.*
+
+### Validation
+
+`validateAPI()` is called from `Validate()` and returns immediately unless
+`api.enabled` is true. This is the dormancy guarantee: a repo can commit the
+block today, before docz-api or docz-site understand it, and `docz` keeps
+loading the config without complaint.
+
+When enabled, every path — `landing_page`, each `exclude` entry, each
+`additional_docs` entry — goes through the shared repo-relative path rules
+extracted from `validateChangelog` (INV-0007 Decision 2), wrapping:
+
+```go
+var ErrInvalidAPIPath = errors.New("invalid api path")
+```
+
+Rules specific to this block:
+
+- An empty `exclude` or `additional_docs` entry is an error. An empty string in
+  a list is always a mistake, unlike an omitted scalar which has a default.
+- Duplicate `additional_docs` entries are an error — after `./` stripping, two
+  entries naming the same file would produce two nav items for one document.
+- An `additional_docs` entry under `docs_dir` is an error (consumption rule 6).
+- An `additional_docs` entry whose **first path segment matches an enabled
+  type's `dir` or canonical name** is an error. This is the one route
+  ambiguity that dropping the namespace segment leaves open: a repo-root
+  `design/notes.md` would address as `/:owner/:repo/design/notes.md`, which
+  the router cannot distinguish from `/:owner/:repo/:type/:docId`. Catching it
+  at load time is the same move `validateResolution` already makes for
+  colliding type tokens.
+
+Validation is **path-shape only**. It never checks that a file exists — it
+cannot, since docz-api validates a config it fetched from a git tree with no
+checkout. Consumers skip missing files and report them.
+
+### Titles for frontmatter-less documents
+
+This is the part that is not just config, and the reason INV-0007 concluded the
+feature is not purely additive.
+
+Every document docz describes today has frontmatter, so a display title is
+always `Frontmatter.Title`. `CONTRIBUTING.md` and `docs/examples/README.md`
+have none. Something must derive a title for the site's nav, breadcrumbs, and
+search results, and the only signal in the file is its H1.
+
+docz already implements exactly this logic — in `internal/wiki/titles.go`, via
+an unexported `firstH1` behind a path-based `DocTitle`. Both facts disqualify
+it: `internal/` is unreachable from another module (the `test/consumer/`
+proof), and docz-api has bytes, not paths. Meanwhile `docparse.Headings`
+**deliberately excludes H1**, because in a docz document the H1 is the title
+and would pollute a ToC.
+
+So docz adds one function (INV-0007 Decision 1):
+
+```go
+// Title returns the text of the first H1 heading in content, with inline
+// markdown stripped, or "" if there is none.
+func Title(content []byte) string
+```
+
+`""` is a normal outcome, not an error — the consumer supplies its own
+fallback, typically the filename, exactly as docz-api already defaults a
+missing changelog title. That keeps `docparse`'s no-error contract intact and
+keeps presentation decisions consumer-side, per ADR-0001. `Headings` is
+untouched, so its frozen H2–H6 behavior does not change.
+
+### Route mapping (non-normative)
+
+docz does not construct routes. This section records the intended mapping so
+docz, docz-api, and docz-site agree on what the config means.
+
+| Source | Route |
+| ------ | ----- |
+| `docs/index.md` (landing page) | `/:owner/:repo` |
+| `docs/impl/README.md` (generated index) | `/:owner/:repo/impl` |
+| `docs/impl/0015-foo.md` | `/:owner/:repo/impl/IMPL-0015` |
+| `docs/examples/README.md` | `/:owner/:repo/examples` |
+| `docs/examples/example1.md` | `/:owner/:repo/examples/example1` |
+| `CONTRIBUTING.md` (additional) | `/:owner/:repo/CONTRIBUTING` |
+
+The path is `docs_dir`-relative with no namespace segment, so the URL space is
+a direct mirror of the `docs_dir` tree. This is coherent with DESIGN-0009's
+existing map rather than an addition to it: `/:owner/:repo` is already "repo
+detail" (now backed by `docs/index.md`) and `/:owner/:repo/:type` is already
+"list of documents of one type" (now backed by `docs/<type>/README.md`, which
+is what docz-site serves there today).
+
+The index-file rule in consumption rule 2 is what makes the mirror uniform: a
+directory's page is its `README.md`, whether or not the directory is a type.
+Note this revises the mapping sketched in `.docz.example.yaml`, which had
+`docs/examples/README.md → .../examples/README.md`; under the uniform rule it
+is `.../examples`, matching how `docs/impl/README.md → .../impl` already works.
+
+One thing left to docz-site: **whether `.md` appears in the URL**
+(`/examples/example1` vs `/examples/example1.md`). docz supplies the path with
+its extension; stripping it is presentation.
+
+## API / Interface Changes
+
+| Change | Surface | Kind |
+| ------ | ------- | ---- |
+| `APIConfig` struct | `pkg/doczcore/config` | Additive |
+| `Config.API` field | `pkg/doczcore/config` | Additive |
+| `ErrInvalidAPIPath` sentinel | `pkg/doczcore/config` | Additive |
+| `DefaultConfig()` gains a dormant `API` value | `pkg/doczcore/config` | Additive |
+| `Validate()` rejects bad paths **when enabled** | `pkg/doczcore/config` | Additive (dormant block unaffected) |
+| `docparse.Title(content []byte) string` | `pkg/doczcore/docparse` | Additive |
+| Shared repo-relative path validator | `pkg/doczcore/config`, unexported | Internal refactor |
+| Dormant `api:` block in generated config | `internal/template/templates/docz_yaml.tmpl` | Golden regen |
+
+Nothing is removed or changed in meaning, so this is a **minor** release under
+ADR-0001's roll-forward semver: `v1.2.0`.
+
+No CLI changes. No `cmd/` changes.
+
+### Downstream contract (what docz-api pins as R10)
+
+DESIGN-0008 lists requirements R1–R9 that the docz repo must satisfy for
+docz-api. This design adds **R10**, in the same form:
+
+> **R10.** `pkg/doczcore/config` exposes `Config.API` with `Enabled`,
+> `LandingPage`, `Exclude []string`, and `AdditionalDocs []string`. Paths are
+> repo-relative, `./`-stripped, forward-slash separated, and guaranteed by
+> `Validate()` — when `api.enabled` is true — to contain no absolute prefix,
+> volume name, `~`, `..`, `.`, empty segment, backslash, control character, or
+> trailing `/`. `AdditionalDocs` entries are unique, lie outside `docs_dir`,
+> and never begin with an enabled type's directory name.
+> `pkg/doczcore/docparse` exposes `Title(content []byte) string`, returning `""`
+> when a document has no H1, so consumers derive titles for frontmatter-less
+> documents without reimplementing the rule. Available from docz `v1.2.0`.
+
+Three consequences docz-api should treat as explicit, because each is easy to
+rediscover as a bug:
+
+- **The tree filter widens from `docs_dir/<type.dir>/` to `docs_dir/`.** The
+  push-diff intersection in DESIGN-0008 step 4 widens the same way. This is a
+  relaxation of an existing filter rather than a new fetch path — the recursive
+  listing is already in hand.
+- **`additional_docs` still needs its own lookup**, because those files are
+  outside `docs_dir` by definition.
+- **Path-addressed documents fail `document.IsDoczFile`.** The pattern is
+  `^(\d+)-.*\.md$`; `CONTRIBUTING.md` and `examples/README.md` never match. An
+  ingestion loop shaped as "scan → keep `IsDoczFile`" silently drops all of
+  them. That predicate is now the *discriminator* between the two record types
+  inside a type directory, not a global filter — and the `README.md` in each
+  type directory must be kept despite failing it, because that file is the
+  type page's body (consumption rule 2). Dropping it is the most likely way to
+  get this wrong, since it is the one file that both fails `IsDoczFile` and
+  lives inside a type directory.
+
+## Data Model
+
+docz itself stores nothing — the config *is* the model. For consumers, the
+shape implied is a second record type alongside `documents`:
+
+| Field | Source |
+| ----- | ------ |
+| `repo_id` | ingestion context |
+| `path` | `docs_dir`-relative path, or repo-relative for `additional_docs` |
+| `title` | `docparse.Title`; fall back to the filename when it returns `""` |
+| `content` / `content_hash` | fetched blob, same gating as documents |
+
+Keying is `(repo_id, path)` rather than `(repo_id, doc_id)` — path-addressed
+documents have no id, which is precisely why DESIGN-0009's document route does
+not fit them unchanged.
+
+Ordering is by path. The enumerate-everything form of this design would have
+given presentation order from list position; auto-consumption does not, and
+nobody has asked for a curated `docs/` nav.
+
+The landing page is a nullable pointer on the repo record rather than a row in
+this table; it is one per repo and addressed as the repo root.
+
+## Testing Strategy
+
+Mirrors IMPL-0015's approach for `changelog:`.
+
+**Unit — `pkg/doczcore/config`:**
+
+- Decode: full block, partial block, absent block, `enabled` alone.
+- Defaults: `DefaultConfig()` yields a dormant block; a config with no `api:`
+  key round-trips identically to today.
+- Normalization: `./` stripping on all three path-bearing fields;
+  `landing_page` backfill when empty and enabled, including under a non-default
+  `docs_dir`; **no** backfill when disabled; `..` survives normalization so
+  validation can see it.
+- Validation, enabled: every rejection class — absolute, volume name, `~`,
+  backslash, control char, trailing `/`, `..`, `.`, empty segment, empty
+  entry, duplicate entry, entry under `docs_dir`, entry whose first segment is
+  an enabled type dir. Each asserted with `errors.Is(err, ErrInvalidAPIPath)`,
+  not string matching.
+- Validation, disabled: **every** rejection class above passes when
+  `api.enabled` is false. This is the dormancy guarantee, and it deserves the
+  same table-driven exhaustiveness as the positive cases.
+- Type-collision validation interacts with enablement: a first segment matching
+  a *disabled* type's dir is allowed.
+- Merge: global + repo config, repo wins, `exclude` and `additional_docs`
+  **replace** rather than append under the existing deep merge — worth an
+  explicit test, since a reader may assume otherwise.
+
+**Unit — `docparse.Title`:** golden fixtures under `docparse/testdata/`, per
+the package's existing pattern. Cases: plain H1; H1 with inline markdown; H1
+inside a fence (not a title); setext H1 (`===` underline — decide and pin the
+behavior); no H1 at all; H1 not on the first line; multiple H1s (first wins);
+H1 after frontmatter; empty input.
+
+**Consumer proof — `test/consumer/`:** extend the existing external-module test
+to read `cfg.API` and call `docparse.Title` by their public paths, proving the
+surface is importable exactly as docz-api will import it.
+
+**Parity:** `parity_baseline_test.go` continues to pin lenient unknown-key
+decoding and case-sensitivity; the new block must not disturb either.
+
+## Migration / Rollout Plan
+
+1. **Ship dormant.** `v1.2.0` adds the schema, normalization, validation,
+   `docparse.Title`, and the default-off block in `docz init` output. Repos
+   without an `api:` key are byte-for-byte unaffected.
+2. **Repos opt in.** A repo adds the block and turns it on whenever it likes.
+   Because validation is enabled-gated, a repo can commit it `enabled: false`
+   first and flip later.
+3. **docz-api bumps its pin** to `v1.2.0`, widens the tree filter, adds the
+   `additional_docs` lookup and the path-addressed record type, and pins R10.
+4. **docz-site** backs `/:owner/:repo` with the landing page and adds the
+   path-addressed catch-all route.
+
+Rollback is trivial: the block is opt-in and inert to the CLI, so downgrading
+docz only means the config carries a key nothing reads — the same lenient
+unknown-key path that already lets an older docz load a newer config.
+
+There is no data migration, because docz stores nothing.
+
+The one operational caution: **flipping `api.enabled` publishes every `.md`
+under `docs_dir`.** A repo with `docs/scratch/` or a stray `docs/TEMP-design.md`
+(this repo had exactly that during IMPL-0015) publishes it unasked. That is the
+cost of not enumerating, and `api.exclude` is the mitigation. Worth a sentence
+in the README and in the generated config's comments.
+
+## Open Questions
+
+**None.** All ten were resolved on 2026-08-10; see **Decisions** below. The
+question that produced Decision 10 is kept here for its alternatives, since a
+future asset design will want them.
+
+### 10. Should images and other assets be consumed?
+
+Markdown under `docs_dir` routinely references relative images
+(`![diagram](./images/arch.png)`). If only `.md` is ingested, those render
+broken. DESIGN-0008 does not mention assets at all — there is no existing
+answer to inherit, and whether docz-api serves blob content for non-markdown
+today is a question for that repo.
+
+- **a. (Recommendation) Out of scope for docz; no config, no schema change.**
+  docz's rule stays `.md`-only for the *document* set. Assets are not
+  documents — they have no title, no nav entry, no search body — so modeling
+  them alongside documents is a category error. docz-api can fetch a fixed set
+  of image extensions under `docs_dir` and serve them at their
+  `docs_dir`-relative path with no docz involvement, because this design
+  already defines that path mapping. Revisit only if it needs to be
+  configurable per repo.
+- **b. Add `api.assets` now** — either an extension list or a path list. Makes
+  it explicit and repo-controlled, but it is speculative config for a need
+  nobody has hit yet, and every extension list is wrong for someone.
+- **c. Resolve links from ingested markdown** and fetch only referenced assets.
+  Precise, no orphan blobs, and self-maintaining. But it needs relative-link
+  parsing, which `docparse` does not provide (`Headings` + `TaskItems` only),
+  so docz-api would parse markdown itself — the duplication INV-0007 F2 argues
+  against, unless docz also grows a `Links` extractor.
+- **d. No asset support.** Images 404. Honest and cheap, but a design doc with
+  a broken architecture diagram is a bad first impression of the site.
+
+## Decisions
+
+All ten open questions resolved **(a)** on 2026-08-10, across three rounds of
+review the same day. The body above reflects the final state; this table
+records how it got there.
+
+| # | Question | Resolution |
+| - | -------- | ---------- |
+| 1 | Entry shape for `additional_docs` | Bare strings — path only, title from the H1. Upgradeable to a scalar-or-mapping union later without a break, but only if we start from strings |
+| 2 | `api.index` naming | **Revised.** Renamed to `api.landing_page`, a single optional string; `APIIndexConfig` dropped entirely. Removes the collision with the top-level `index:` block and a redundant boolean |
+| 3 | Landing page default | `<docs_dir>/index.md`, resolved during normalization so it tracks a non-default `docs_dir`. This repo's existing `docs/index.md` confirms the shape |
+| 4 | Meaning of `enabled: false` | Gates the api surface only. Disabled or absent → docz-api ingests exactly what it does today. The only backward-compatible reading |
+| 5 | Globs | No — literal paths only. Moot under the consumption rule: nothing needs enumerating inside `docs_dir`, and docz cannot expand patterns in the no-checkout model anyway |
+| 6 | Overlap with type dirs | **Revised and strengthened.** "An `additional_docs` entry must not be under `docs_dir`" replaces the per-type-dir check — one prefix test, no type enumeration, stable when a type is disabled |
+| 7 | Missing files | Path-*shape* validation only; docz never checks existence. Consumers skip and report. Anything else makes validity host-dependent |
+| 8 | Route shape | **Revised.** No namespace segment: `/:owner/:repo/*path`, mirroring `docs_dir` directly. Safe for `docs_dir` content because type dirs are reserved; the residual repo-root ambiguity is closed by validation instead |
+| 9 | `docz init` emission | Yes, `enabled: false` with comments — the DESIGN-0010 Decision 6 precedent |
+| 10 | Images and assets | Out of scope for docz — no config, no schema change. Assets are not documents; docz-api can serve them at their `docs_dir`-relative path using the mapping this design already defines |
+
+### Revision history
+
+**2026-08-10, after the first round of answers.** Three changes, all adopted:
+
+1. **Consume the whole `docs_dir`** rather than enumerating extra files. This
+   shrinks the docz-api change to widening an existing filter, makes globs
+   moot, reduces the overlap rule to one prefix check, and turns route mapping
+   from a policy into a coordinate system. `additional_docs` narrows to mean
+   "outside `docs_dir`," which makes it structurally identical to
+   `changelog.file`. Restricted to `*.md` after finding twelve `.sh` files
+   under this repo's `docs/examples/`.
+2. **`api.exclude` added**, with `docs_dir/templates/` always excluded
+   implicitly so the default can be empty. Deliberately *not* mirroring
+   `wiki.exclude`, which also excludes `examples` — docz-site is a different
+   product and should publish `docs/examples/`. This resolves INV-0007 F7
+   rather than leaving it as an apparent inconsistency.
+3. **Decision 8 reversed** from a `docs/` namespace segment to a bare path,
+   plus the first-segment validation rule that makes it unambiguous.
+
+**2026-08-10, third round.** Two corrections:
+
+4. **A directory's `README.md` is that directory's page** — consumption rule 2.
+   The previous draft reserved type directories entirely, which would have made
+   docz-api skip `docs/impl/README.md`; but that file is exactly what
+   docz-site already serves at `/donaldgifford/docz/impl`. Correcting it turned
+   out to *generalize* the model rather than special-case it: the same rule
+   covers `docs/index.md` at the root and `docs/examples/README.md` in a
+   non-type directory, so the URL space mirrors `docs_dir` uniformly. It also
+   revises the mapping sketched in `.docz.example.yaml`, where
+   `docs/examples/README.md` was drawn as `.../examples/README.md` rather than
+   `.../examples`.
+5. **Decision 10 (assets) closed as out of scope**, keeping this design to the
+   config block and `docparse.Title`.
+
+## References
+
+- INV-0007 — the internals audit this design is built on; its three decisions
+  cover `docparse.Title`, the shared path validator, and docz's non-role in
+  route construction
+- DESIGN-0008 — docz-api ingestion pipeline, no-checkout model, requirements
+  R1–R9 (this design proposes R10)
+- DESIGN-0009 — docz-site information architecture and route map
+- DESIGN-0010 / IMPL-0015 — the `changelog:` block: opt-in schema,
+  normalize-then-validate split, dormancy guarantee, and the path-hardening
+  history this design reuses
+- ADR-0001 — five-package public core, whole-package promotion, roll-forward
+  semver, facts-not-interpretation
+- `.docz.example.yaml` — the drafted `api:` block this design formalizes

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -42,4 +42,5 @@ docz create design "Your Design Title"
 | DESIGN-0008 | docz-api: cross-repo docz registry and ingestion service | Approved | 2026-06-23 | Donald Gifford | [0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md](0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md) |
 | DESIGN-0009 | docz-site: cross-repo docz viewer and search UI | Draft | 2026-06-23 | Donald Gifford | [0009-docz-site-cross-repo-docz-viewer-and-search-ui.md](0009-docz-site-cross-repo-docz-viewer-and-search-ui.md) |
 | DESIGN-0010 | Changelog config block and ParseChangelog | Implemented | 2026-08-02 | Donald Gifford | [0010-changelog-config-block-and-parsechangelog.md](0010-changelog-config-block-and-parsechangelog.md) |
+| DESIGN-0011 | api config block: index page and additional_docs for docz-api and docz-site | Draft | 2026-08-10 | Donald Gifford | [0011-api-config-block-index-page-and-additionaldocs-for-docz-api-and.md](0011-api-config-block-index-page-and-additionaldocs-for-docz-api-and.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0014-v100-the-five-package-pkgdoczcore-public-core.md
+++ b/docs/impl/0014-v100-the-five-package-pkgdoczcore-public-core.md
@@ -10,7 +10,7 @@ created: 2026-07-03
 
 # IMPL 0014: v1.0.0: the five-package pkg/doczcore public core
 
-**Status:** In Progress **Author:** Donald Gifford **Date:** 2026-07-03
+**Status:** Completed **Author:** Donald Gifford **Date:** 2026-07-03
 
 <!--toc:start-->
 - [Objective](#objective)

--- a/docs/investigation/0002-architectural-review-and-cleanup-opportunities.md
+++ b/docs/investigation/0002-architectural-review-and-cleanup-opportunities.md
@@ -10,7 +10,7 @@ created: 2026-05-15
 
 # INV 0002: Architectural Review and Cleanup Opportunities
 
-**Status:** In Progress **Author:** Donald Gifford **Date:** 2026-05-15
+**Status:** Concluded **Author:** Donald Gifford **Date:** 2026-05-15
 
 <!--toc:start-->
 - [Question](#question)

--- a/docs/investigation/0007-docz-internals-required-for-the-api-additionaldocs-block.md
+++ b/docs/investigation/0007-docz-internals-required-for-the-api-additionaldocs-block.md
@@ -1,0 +1,425 @@
+---
+id: INV-0007
+title: "docz internals required for the api additional_docs block"
+status: Concluded
+author: Donald Gifford
+created: 2026-08-10
+---
+
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV-0007: docz internals required for the api additional_docs block
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [F1. The config block itself is genuinely small](#f1-the-config-block-itself-is-genuinely-small)
+  - [F2. There is no public way to get a title out of a frontmatter-less markdown file](#f2-there-is-no-public-way-to-get-a-title-out-of-a-frontmatter-less-markdown-file)
+  - [F3. The path-validation rules exist but are not reusable](#f3-the-path-validation-rules-exist-but-are-not-reusable)
+  - [F4. Additional docs have no id, and the whole downstream contract is keyed on id](#f4-additional-docs-have-no-id-and-the-whole-downstream-contract-is-keyed-on-id)
+  - [F5. The ingestion fetcher filters the tree by type dir, so additional docs are invisible to it](#f5-the-ingestion-fetcher-filters-the-tree-by-type-dir-so-additional-docs-are-invisible-to-it)
+  - [F6. Globs cannot be expanded by docz in the consumer's model](#f6-globs-cannot-be-expanded-by-docz-in-the-consumers-model)
+  - [F7. wiki exclude and api additional_docs disagree about examples](#f7-wiki-exclude-and-api-additionaldocs-disagree-about-examples)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [Open Questions](#open-questions)
+  - [1. Where should the H1/title extractor live?](#1-where-should-the-h1title-extractor-live)
+  - [2. Should the path-validation rules be shared between changelog.file and additional_docs?](#2-should-the-path-validation-rules-be-shared-between-changelogfile-and-additionaldocs)
+  - [3. Does docz need to expose the URL/route mapping?](#3-does-docz-need-to-expose-the-urlroute-mapping)
+- [Decisions](#decisions)
+  - [Amendment to Decision 1: the empty-string contract](#amendment-to-decision-1-the-empty-string-contract)
+  - [How the design resolved F5, F6, and F7](#how-the-design-resolved-f5-f6-and-f7)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+DESIGN-0011 proposes an `api:` block in `.docz.yaml` carrying an index page
+and an `additional_docs` list of non-docz markdown files for docz-api and
+docz-site to ingest and render. **Is this purely additive config, or does it
+require changes to docz's internals and public surface?**
+
+The working assumption going in was "there is not much we have to do." This
+investigation is a concrete audit of that assumption.
+
+## Hypothesis
+
+Mostly additive. `ChangelogConfig` (DESIGN-0010 / IMPL-0015) is the exact
+precedent — a new struct, a `DefaultConfig()` entry, a normalization pass, an
+enabled-only validator, a `docz_yaml.tmpl` block — and nothing outside
+`pkg/doczcore/config` changed for it. The expectation was that `api:` would
+follow the same shape and be similarly self-contained.
+
+**The hypothesis is partly wrong.** The config half is as small as expected;
+the *parsing* half is not, because additional docs are the first documents docz
+would describe that have neither frontmatter nor a docz filename.
+
+## Context
+
+**Triggered by:** DESIGN-0011 (`api:` block), which in turn serves DESIGN-0008
+(docz-api ingestion) and DESIGN-0009 (docz-site route map). The immediate
+prompt was the `api:` section drafted in `.docz.example.yaml`.
+
+This matters *now* rather than later because `pkg/doczcore` is frozen under
+semver (ADR-0001): additive changes are a minor bump, but a helper that turns
+out to be needed after the fact is either a second minor release or a
+consumer-side reimplementation that drifts from docz's own behavior.
+
+## Approach
+
+1. Read the drafted `api:` block in `.docz.example.yaml` and enumerate every
+   field it implies.
+2. Trace the `ChangelogConfig` precedent end to end to establish what "purely
+   additive config" actually costs.
+3. For each field, ask what a consumer must *do* with it, and check whether
+   the public surface supports that.
+4. Check DESIGN-0008's ingestion pipeline and DESIGN-0009's route map for
+   assumptions that additional docs would violate.
+5. Grep the public packages for the specific capabilities implied (title
+   extraction, path validation, filename classification).
+
+## Environment
+
+| Component | Version / Value |
+| --------- | --------------- |
+| docz | `v1.1.0` (frozen `pkg/doczcore`, ADR-0001) |
+| Branch | `docs/design-api-additional-docs` |
+| Precedent | DESIGN-0010 / IMPL-0015 (`changelog:` block) |
+| Consumers | docz-api (DESIGN-0008), docz-site (DESIGN-0009) |
+
+## Findings
+
+### F1. The config block itself is genuinely small
+
+The `changelog:` precedent is a fair estimate for the `api:` block. Everything
+`ChangelogConfig` needed lives in one package:
+
+- `pkg/doczcore/config/config.go` — the struct, the `Config` field, the
+  `DefaultConfig()` entry, `normalizeChangelog`, `validateChangelog`
+- `pkg/doczcore/config/constants.go` — `DefaultChangelogFile`
+- `internal/template/templates/docz_yaml.tmpl` — the dormant block
+
+`Load` already has the hook points: `fillTypeFieldDefaults(&cfg)` followed by
+`normalizeChangelog(&cfg)` at both `Load` call sites (`config.go:211` and
+`:651`). An `normalizeAPI(&cfg)` slots in beside it with no restructuring.
+
+`api:` is a deeper shape (a nested `index:` object and a string slice rather
+than two scalars), but nothing about it is structurally new. **This half of the
+hypothesis holds.**
+
+### F2. There is no public way to get a title out of a frontmatter-less markdown file
+
+This is the finding that breaks the assumption.
+
+Every document docz currently describes has YAML frontmatter, so a display
+title is always `Frontmatter.Title`. `additional_docs` points at
+`CONTRIBUTING.md`, `DEVELOPMENT.md`, `docs/examples/README.md` — ordinary
+markdown with **no frontmatter at all**. Something has to produce a human
+title for the site's nav, breadcrumbs, and search results.
+
+docz already solves this, in the wrong place and with the wrong signature:
+
+```go
+// internal/wiki/titles.go
+func DocTitle(filePath string) (string, error)   // ← internal/, and path-based
+func firstH1(data []byte) string                 // ← unexported
+```
+
+Two independent blockers:
+
+1. **`internal/wiki` is unreachable from another module.** This is not a
+   guess — `test/consumer/` exists precisely to prove it, and IMPL-0014
+   recorded the spot-check that importing `internal/template` from outside
+   fails with `use of internal package ... not allowed`.
+2. **`DocTitle` reads from disk.** docz-api never has a checkout (DESIGN-0008
+   Decision 1 — Git Trees API, blobs fetched as bytes). Even promoted verbatim
+   it would be unusable; the consumer needs bytes-in, exactly the argument
+   R3 already made for `ParseFrontmatter` over `ScanDocuments`.
+
+And the obvious public candidate does not cover it. `docparse.Headings`
+**deliberately excludes H1**:
+
+```go
+// pkg/doczcore/docparse/headings.go:11
+// Level is the heading depth, 2 through 6. H1 headings are
+// excluded: in docz documents the H1 is the document title, which
+```
+
+That exclusion is correct for docz documents and exactly wrong for additional
+docs, where the H1 *is* the only title available.
+
+**Net:** with today's surface, docz-api must reimplement H1 extraction. That
+means duplicating fence-awareness, ATX parsing, and inline-markdown stripping —
+all of which `docparse` already implements and pins with goldens — in a second
+codebase, where it will drift. This is the precise failure mode ADR-0001's
+"one definition module-wide" rule exists to prevent (`docwrite.CheckTask`
+validating through `docparse.TaskItems` is the same rule applied earlier).
+
+### F3. The path-validation rules exist but are not reusable
+
+`additional_docs` entries are repo-relative paths fetched out of a git tree —
+byte for byte the same trust problem as `changelog.file`. IMPL-0015 hardened
+that path against traversal, host-dependent separator semantics, `~`
+expansion, control characters, and non-canonical segments, and those rules
+were expensive to get right (a real bypass shipped in review and was caught
+pre-tag).
+
+The rules currently live in an unexported method:
+
+```go
+func (c *Config) validateChangelog() error   // config.go:450
+func hasVolumeName(p string) bool            // config.go, unexported
+```
+
+So `additional_docs` cannot reuse them without either extracting a shared
+helper or copy-pasting the switch. Copy-pasting is how the two validators
+drift apart the next time one is hardened.
+
+Note this is *internal* reuse — no new export is required, since validation
+runs inside `Validate()` and the consumer only sees the error. That keeps the
+fix cheap.
+
+### F4. Additional docs have no id, and the whole downstream contract is keyed on id
+
+DESIGN-0009's route map addresses a document as:
+
+```
+/:owner/:repo/:type/:docId      e.g. .../design/DESIGN-0009
+```
+
+and notes "`:docId` is the stable frontmatter id ... unique within a repo, so
+`(owner, repo, docId)` is a stable permalink." DESIGN-0008's data model keys
+`documents` on `(repo_id, doc_id)` and computes `content_hash` per doc.
+
+An additional doc has **no type and no id**. It cannot be addressed by that
+route shape at all. The example URLs in `.docz.example.yaml` are a different
+shape entirely — path-based, and rooted at `/repos/${repo-name}/`:
+
+```
+./docs/examples/README.md -> ${docz-site-url}/repos/${repo-name}/examples/README.md
+./CONTRIBUTING.md         -> ${docz-site-url}/repos/${repo-name}/CONTRIBUTING.md
+```
+
+Two mismatches with the existing design, both worth resolving in DESIGN-0011
+rather than discovering during implementation:
+
+- **Prefix.** The drafted URLs carry `/repos/`; DESIGN-0009's map has
+  `/:owner/:repo` at the root with no `/repos/` prefix (`/repos` is only the
+  *list* route).
+- **Owner.** The drafted URLs use a single `${repo-name}`; DESIGN-0009 uses
+  `:owner/:repo` because owner+repo together identify a repo.
+
+This is a docz-site/docz-api concern, not a docz-CLI one — but it determines
+whether `additional_docs` needs to carry anything beyond a path (a slug? a
+title override? a nav position?), which *is* a docz config-schema question.
+
+### F5. The ingestion fetcher filters the tree by type dir, so additional docs are invisible to it
+
+DESIGN-0008 step 1 is explicit:
+
+> filter to `.docz.yaml` and blobs under `docs_dir/<type.dir>/`
+
+`CONTRIBUTING.md` at the repo root is outside that filter, and so is
+`docs/examples/README.md` (`examples` is not a type dir). The push-diff
+optimization in step 4 has the same shape — it intersects changed paths with
+`docs_dir`.
+
+Consequently docz-api needs a second, config-driven fetch set. That is
+entirely docz-api's work, but it confirms `additional_docs` is not something a
+consumer picks up for free by reading the config — it changes the pipeline.
+
+Related: `document.IsDoczFile` is `^(\d+)-.*\.md$`, so every additional doc
+fails it by construction. Any consumer loop written as "scan dir → keep
+`IsDoczFile`" silently drops all of them. Worth stating in the contract so it
+is not rediscovered as a bug.
+
+### F6. Globs cannot be expanded by docz in the consumer's model
+
+The natural next request after `additional_docs` is `docs/examples/*.md`. docz
+cannot expand that for docz-api: pattern expansion needs a listing, docz-api
+has a git tree rather than a filesystem, and `pkg/doczcore` is
+stdlib-and-bytes only by ADR-0001.
+
+Either the consumer expands patterns against its own tree listing (in which
+case docz's role is to define the syntax and validate it, not to resolve it),
+or v1 ships literal paths only. The CLI could expand globs locally via
+`filepath.Glob` and diverge from the consumer — which would be worse than not
+supporting them.
+
+### F7. wiki exclude and api additional_docs disagree about examples
+
+`DefaultConfig()` sets `Wiki.Exclude: []string{"templates", "examples"}`, and
+the drafted `api:` block lists `./docs/examples/README.md` as an additional
+doc. Both are defensible — the MkDocs nav and the docz-site surface are
+different products — but a reader will notice one config excluding what the
+other includes. Worth an explicit sentence rather than leaving it as apparent
+inconsistency.
+
+## Conclusion
+
+**Answer: No — this is not purely additive config.** The config block is as
+small as hypothesized (F1), but the feature as drafted needs one genuine
+addition to the frozen public surface and one internal refactor:
+
+| Need | Where | Cost |
+| ---- | ----- | ---- |
+| `APIConfig` struct, defaults, normalize, validate | `pkg/doczcore/config` | Additive, minor bump |
+| Dormant `api:` block | `internal/template/templates/docz_yaml.tmpl` | Trivial (+ golden regen) |
+| **Public H1 / title extractor, bytes-in** | `pkg/doczcore/docparse` or `document` | **Additive, minor bump — the real finding** |
+| Shared repo-relative path validator | `pkg/doczcore/config`, unexported | Internal refactor, no API change |
+
+None of it is breaking, so the whole thing is one **minor** release. But
+shipping the config without the title extractor would push H1 parsing into
+docz-api, which is the duplication ADR-0001 exists to prevent — so they should
+ship together.
+
+## Recommendation
+
+1. **Ship the config block and the title extractor in the same minor release.**
+   Splitting them guarantees docz-api writes its own H1 parser in the gap.
+2. **Extract the repo-relative path rules into one unexported helper** and
+   have both `validateChangelog` and the new `validateAPI` call it, before
+   there are two hardening histories to keep in sync.
+3. **Resolve the route shape in DESIGN-0011** (F4) before implementing, since
+   it determines whether `additional_docs` entries are bare strings or objects.
+   Changing that after the config ships is a breaking schema change.
+4. **Defer globs** (F6). Literal paths only for v1; revisit once docz-api has
+   a working tree-listing path.
+5. **Add the contract clause** (call it R10) to DESIGN-0008's requirements
+   list, in the same form as R1–R9, so docz-api has an explicit acceptance
+   criterion rather than an inference from this INV.
+
+## Open Questions
+
+### 1. Where should the H1/title extractor live?
+
+The one new public symbol this feature actually requires (F2). It must be
+bytes-in, must be fence-aware, and must not disturb `docparse.Headings`'
+frozen H2–H6 contract.
+
+- **a. (Recommendation) `docparse.Title(content []byte) string`** — a new
+  function in `docparse` returning the first H1's stripped text, or `""` when
+  there is none. `docparse` is already the module's markdown fact extractor,
+  is already fence-aware, already has `AnchorSlug` and inline-markdown
+  stripping to reuse, and its no-error / facts-not-interpretation contract fits
+  a "" return exactly. `Headings` keeps excluding H1, so nothing existing
+  changes.
+- **b. `docparse.Headings` starts including H1** with a `Level: 1` entry, and
+  consumers filter. Truthful to the name, but it is a **breaking behavior
+  change** to a frozen function — every existing caller (`toc`, and any
+  consumer ToC) would suddenly emit the document title as a ToC entry.
+- **c. `document.Title(content []byte) string`** — put it beside
+  `ParseFrontmatter`, arguing that "title" is a document concern rather than a
+  markdown fact. Keeps docz-api's imports to one package, but splits markdown
+  parsing across two packages and duplicates fence handling (the same tension
+  DESIGN-0010 Decision 1 already navigated for `ParseChangelog`).
+- **d. `document.DocTitle(content []byte, filename string) string`** — the
+  full `internal/wiki` fallback chain promoted: frontmatter `ID: Title`, then
+  H1, then title-cased filename. Most useful to the consumer, but it bakes a
+  presentation policy ("`ID: Title`") into the frozen core, which ADR-0001
+  says belongs consumer-side.
+- **e.** Ship nothing; let docz-api extract the H1 itself.
+
+### 2. Should the path-validation rules be shared between `changelog.file` and `additional_docs`?
+
+Both are repo-relative paths a consumer fetches from a git tree, and F3 shows
+the hardened rules are currently locked inside `validateChangelog`.
+
+- **a. (Recommendation) Extract one unexported
+  `validateRepoRelativePath(field, value string) error`** and call it from
+  both, each wrapping its own sentinel. One hardening history, no new public
+  API, and the error text stays field-specific.
+- **b. Duplicate the switch** into `validateAPI`. Zero refactor risk today,
+  guaranteed drift the next time either is hardened.
+- **c. Export it as `config.ValidateRepoPath`** so docz-api can pre-validate
+  paths itself. Adds public surface to the frozen package for a case the
+  consumer gets for free via `Validate()`.
+- **d.** Relax the rules for `additional_docs` (allow `..`), on the grounds
+  that these are explicitly-listed files rather than a computed path. Not
+  recommended — it reintroduces exactly the traversal the changelog validator
+  rejects, for the same fetch-from-tree consumer.
+
+### 3. Does docz need to expose the URL/route mapping?
+
+F4 shows the drafted URL shape does not match DESIGN-0009's route map. Whoever
+owns that mapping owns a compatibility surface.
+
+- **a. (Recommendation) No — docz stores and validates config only.** Route
+  construction is docz-site's concern; docz-api serves paths and titles.
+  Consistent with ADR-0001 (facts, not interpretation) and keeps docz out of
+  the site's URL-versioning problem. DESIGN-0011 still documents the
+  *intended* mapping as non-normative prose so the three repos agree.
+- **b. docz exposes a helper** (e.g. `config.APIDocRoute(path) string`)
+  implementing the "strip `docs/`, keep folders" rule. One definition, but it
+  freezes a site URL policy into a Go library that ships on a different
+  release cadence than the site.
+- **c. `additional_docs` entries become objects** carrying an explicit
+  `route:`/`slug:` per file, so no mapping rule is needed at all. Most
+  flexible and most verbose; also the only option that must be decided
+  *before* the schema ships, since string→object is a breaking change.
+
+## Decisions
+
+All three open questions resolved **(a)** on 2026-08-10.
+
+| # | Question | Resolution |
+| - | -------- | ---------- |
+| 1 | H1 extractor home | `docparse.Title(content []byte) string` — new function in `docparse`, returns the first H1's stripped text or `""`. `Headings` keeps excluding H1, so nothing frozen changes |
+| 2 | Share the path validator | Extract one unexported `validateRepoRelativePath`; `validateChangelog` and `validateAPI` both call it and wrap their own sentinel. No new public API |
+| 3 | Expose route mapping | No — docz stores and validates config only. Route construction is docz-site's; DESIGN-0011 documents the intended mapping as non-normative prose |
+
+### Amendment to Decision 1: the empty-string contract
+
+Resolving (1a) added an explicit consumer-side rule: **`Title` returning `""` is
+a normal outcome, not an error**, and the consumer supplies its own fallback —
+the filename, exactly as docz-api already defaults a missing changelog title.
+
+This keeps the split clean and is the same division ADR-0001 draws everywhere
+else: docz reports the fact (there is no H1), the consumer decides the
+presentation (call it `CONTRIBUTING`). It also means `Title` needs no error
+return and no sentinel, preserving `docparse`'s no-error contract exactly.
+
+One note for the consumer: `wiki.FilenameTitle` — docz's own
+basename-to-title-case helper — is in `internal/wiki` and therefore
+unreachable, like `DocTitle` itself (F2). docz-api writes its own. That is
+acceptable here in a way the H1 rule was not: title-casing a basename is a
+presentation choice with no markdown grammar behind it, so two implementations
+diverging is a cosmetic difference rather than a correctness bug.
+
+### How the design resolved F5, F6, and F7
+
+DESIGN-0011 settled on consuming every `.md` under `docs_dir` rather than
+enumerating extra files, which changes what two of these findings cost:
+
+- **F5 softens.** docz-api widens its existing `docs_dir/<type.dir>/` tree
+  filter to `docs_dir/` — a relaxation of a filter it already applies to a
+  listing it already has, not a new fetch path. Only `additional_docs`, now
+  meaning "outside `docs_dir`," needs a separate lookup.
+- **F6 becomes moot.** Nothing inside `docs_dir` needs enumerating, so the
+  pressure for glob support largely disappears. The finding still stands as the
+  reason docz should not add globs later.
+- **F7 is resolved rather than deferred.** `api.exclude` defaults to empty with
+  `docs_dir/templates/` always excluded, deliberately *not* mirroring
+  `wiki.exclude`'s `examples` entry — docz-site should publish
+  `docs/examples/`, MkDocs nav should not. Different products, different
+  defaults, now stated.
+
+**F2 is unchanged and remains the finding that mattered**: auto-consumption
+increases the number of frontmatter-less documents rather than reducing it, so
+`docparse.Title` is more necessary under the final design, not less.
+
+## References
+
+- DESIGN-0011 — the `api:` block this investigation supports
+- DESIGN-0008 §Ingestion pipeline, §Requirements for the docz repo (R1–R9)
+- DESIGN-0009 §Information architecture and route map
+- DESIGN-0010 / IMPL-0015 — the `changelog:` block precedent and its
+  path-hardening history
+- ADR-0001 — the five-package public core, whole-package promotion, and the
+  one-definition-module-wide rule
+- `internal/wiki/titles.go` — the existing, unreachable title logic
+- `pkg/doczcore/docparse/headings.go:11` — the H1 exclusion

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -19,6 +19,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0004 | v1 Release Plan: TUI, Markdown Preview, and CLI Parity | Open | 2026-05-22 | Donald Gifford | [0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md](0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md) |
 | INV-0005 | docz-api and docz-site: centralized cross-repo docz registry and viewer | Concluded | 2026-06-23 | Donald Gifford | [0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md](0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md) |
 | INV-0006 | Per-package core requirements: docz CLI vs docz-api, docz-site, sdk-booty-sh | Open | 2026-07-03 | Donald Gifford | [0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md](0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md) |
+| INV-0007 | docz internals required for the api additional_docs block | Concluded | 2026-08-10 | Donald Gifford | [0007-docz-internals-required-for-the-api-additionaldocs-block.md](0007-docz-internals-required-for-the-api-additionaldocs-block.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/internal/template/golden_test.go
+++ b/internal/template/golden_test.go
@@ -26,10 +26,12 @@ func TestGoldenTemplates(t *testing.T) {
 	}
 
 	types := map[config.DocType]Data{
-		"rfc":    data,
-		"adr":    withOverrides(&data, "adr", "ADR", "Proposed"),
-		"design": withOverrides(&data, "design", "DESIGN", "Draft"),
-		"impl":   withOverrides(&data, "impl", "IMPL", "Draft"),
+		"rfc":           data,
+		"adr":           withOverrides(&data, "adr", "ADR", "Proposed"),
+		"design":        withOverrides(&data, "design", "DESIGN", "Draft"),
+		"impl":          withOverrides(&data, "impl", "IMPL", "Draft"),
+		"plan":          withOverrides(&data, "plan", "PLAN", "Draft"),
+		"investigation": withOverrides(&data, "investigation", "INV", "Open"),
 	}
 
 	for typeName, td := range types {

--- a/internal/template/templates/adr.md
+++ b/internal/template/templates/adr.md
@@ -5,16 +5,17 @@ status: {{ .Status }}
 author: {{ .Author }}
 created: {{ .Date }}
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# {{ .Number }}. {{ .Title }}
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
 
 <!--toc:start-->
 <!--toc:end-->
 
-## Status
+## Summary
 
-{{ .Status }}
+<!-- Brief 2-3 sentence summary of the proposal -->
 
 ## Context
 
@@ -23,6 +24,10 @@ created: {{ .Date }}
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
+
+### Supporting Data
+
+<!-- Data gathered that support the proposed solution. -->
 
 ## Consequences
 

--- a/internal/template/templates/design.md
+++ b/internal/template/templates/design.md
@@ -5,13 +5,10 @@ status: {{ .Status }}
 author: {{ .Author }}
 created: {{ .Date }}
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# DESIGN {{ .Number }}: {{ .Title }}
-
-**Status:** {{ .Status }}
-**Author:** {{ .Author }}
-**Date:** {{ .Date }}
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
 
 <!--toc:start-->
 <!--toc:end-->

--- a/internal/template/templates/impl.md
+++ b/internal/template/templates/impl.md
@@ -5,13 +5,10 @@ status: {{ .Status }}
 author: {{ .Author }}
 created: {{ .Date }}
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# IMPL {{ .Number }}: {{ .Title }}
-
-**Status:** {{ .Status }}
-**Author:** {{ .Author }}
-**Date:** {{ .Date }}
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
 
 <!--toc:start-->
 <!--toc:end-->
@@ -98,7 +95,7 @@ are checked off and its success criteria are met.
 <!-- Key files that will be created or modified -->
 
 | File | Action | Description |
-|------|--------|-------------|
+| ---- | ------ | ----------- |
 |      | Create |             |
 |      | Modify |             |
 

--- a/internal/template/templates/rfc.md
+++ b/internal/template/templates/rfc.md
@@ -5,13 +5,10 @@ status: {{ .Status }}
 author: {{ .Author }}
 created: {{ .Date }}
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# RFC {{ .Number }}: {{ .Title }}
-
-**Status:** {{ .Status }}
-**Author:** {{ .Author }}
-**Date:** {{ .Date }}
+# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
 
 <!--toc:start-->
 <!--toc:end-->
@@ -22,32 +19,24 @@ created: {{ .Date }}
 
 ## Problem Statement
 
-<!-- What problem does this RFC address? Include evidence and impact. -->
+<!-- What problem does this RFC address? Include supporting data, evidence and impact. -->
+
+### Supporting Data
+
+<!-- Data gathered that support the proposed solution. -->
 
 ## Proposed Solution
 
 <!-- High-level description of the proposed approach -->
 
-## Design
-
-<!-- Detailed design including architecture, data flow, APIs, etc. -->
-
 ## Alternatives Considered
 
 <!-- What other approaches were evaluated and why were they rejected? -->
 
-## Implementation Phases
-
-<!-- Break the implementation into phases/milestones -->
-
-### Phase 1: ...
-
-### Phase 2: ...
-
 ## Risks and Mitigations
 
 | Risk | Impact | Likelihood | Mitigation |
-|------|--------|------------|------------|
+| ---- | ------ | ---------- | ---------- |
 |      |        |            |            |
 
 ## Success Criteria

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
         - 'DESIGN-0008: docz-api: cross-repo docz registry and ingestion service': design/0008-docz-api-cross-repo-docz-registry-and-ingestion-service.md
         - 'DESIGN-0009: docz-site: cross-repo docz viewer and search UI': design/0009-docz-site-cross-repo-docz-viewer-and-search-ui.md
         - 'DESIGN-0010: Changelog config block and ParseChangelog': design/0010-changelog-config-block-and-parsechangelog.md
+        - 'DESIGN-0011: api config block: index page and additional_docs for docz-api and docz-site': design/0011-api-config-block-index-page-and-additionaldocs-for-docz-api-and.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: docz CLI Implementation': impl/0001-docz-cli-implementation.md
@@ -39,6 +40,7 @@ nav:
         - 'INV-0004: v1 Release Plan: TUI, Markdown Preview, and CLI Parity': investigation/0004-v1-release-plan-tui-markdown-preview-and-cli-parity.md
         - 'INV-0005: docz-api and docz-site: centralized cross-repo docz registry and viewer': investigation/0005-docz-api-and-docz-site-centralized-cross-repo-docz-registry-and.md
         - 'INV-0006: Per-package core requirements: docz CLI vs docz-api, docz-site, sdk-booty-sh': investigation/0006-per-package-core-requirements-docz-cli-vs-docz-api-docz-site.md
+        - 'INV-0007: docz internals required for the api additional_docs block': investigation/0007-docz-internals-required-for-the-api-additionaldocs-block.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:

--- a/pkg/doczcore/config/config.go
+++ b/pkg/doczcore/config/config.go
@@ -125,6 +125,10 @@ type Config struct {
 // DefaultConfig returns the built-in default configuration. The per-type
 // metadata (Types and Wiki.NavTitles) is sourced from the DocType
 // registry in doctype.go so adding a new doc type is a single-file edit.
+//
+// Every built-in type is present in Types, but not every one is enabled:
+// "plan" ships with Enabled false. Callers that want the effective set
+// should use Config.EnabledTypes rather than ranging over Types.
 func DefaultConfig() Config {
 	return Config{
 		DocsDir: "docs",
@@ -332,6 +336,9 @@ func (c *Config) resolveType(name string) (string, bool) {
 // types get a stable sort, since Go map iteration is unordered (IMPL-0012
 // Phase 4, Decision 1). Including custom types here is what lets no-argument
 // commands (docz update / init / list / wiki) scaffold and iterate them.
+//
+// Note this is narrower than DocTypeNames: a built-in may ship disabled
+// ("plan" does), so the default result is a subset of the registry.
 func (c *Config) EnabledTypes() []string {
 	enabled := make([]string, 0, len(c.Types))
 	builtin := make(map[string]bool, len(DocTypeNames()))

--- a/pkg/doczcore/config/config_test.go
+++ b/pkg/doczcore/config/config_test.go
@@ -17,14 +17,18 @@ func TestDefaultConfig(t *testing.T) {
 		t.Errorf("DocsDir = %q, want %q", cfg.DocsDir, "docs")
 	}
 
+	// plan is the one built-in that ships disabled: it sits between RFC
+	// and IMPL, a slot most repos fill with DESIGN + IMPL instead.
+	disabledByDefault := map[string]bool{"plan": true}
+
 	for _, typeName := range DocTypeNames() {
 		tc, ok := cfg.Types[typeName]
 		if !ok {
 			t.Errorf("missing type config for %q", typeName)
 			continue
 		}
-		if !tc.Enabled {
-			t.Errorf("type %q should be enabled by default", typeName)
+		if want := !disabledByDefault[typeName]; tc.Enabled != want {
+			t.Errorf("type %q Enabled = %v, want %v", typeName, tc.Enabled, want)
 		}
 		if tc.IDWidth != 4 {
 			t.Errorf("type %q IDWidth = %d, want 4", typeName, tc.IDWidth)
@@ -466,20 +470,33 @@ func TestEnabledTypes(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
 	got := cfg.EnabledTypes()
-	want := []string{"rfc", "adr", "design", "impl", "plan", "investigation"}
+	want := []string{"rfc", "adr", "design", "impl", "investigation"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("EnabledTypes() = %v, want registry-order %v", got, want)
 	}
 
-	// Disable a type and confirm it drops out of the registry-order list.
+	// Enabling plan slots it back into registry order rather than
+	// appending it, which is what distinguishes a built-in from a custom
+	// type in EnabledTypes.
 	tc := cfg.Types["plan"]
-	tc.Enabled = false
+	tc.Enabled = true
 	cfg.Types["plan"] = tc
 
 	got = cfg.EnabledTypes()
-	want = []string{"rfc", "adr", "design", "impl", "investigation"}
+	want = []string{"rfc", "adr", "design", "impl", "plan", "investigation"}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("EnabledTypes() with plan disabled = %v, want %v", got, want)
+		t.Errorf("EnabledTypes() with plan enabled = %v, want %v", got, want)
+	}
+
+	// Disable a type and confirm it drops out of the registry-order list.
+	tc = cfg.Types["impl"]
+	tc.Enabled = false
+	cfg.Types["impl"] = tc
+
+	got = cfg.EnabledTypes()
+	want = []string{"rfc", "adr", "design", "plan", "investigation"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("EnabledTypes() with impl disabled = %v, want %v", got, want)
 	}
 }
 
@@ -608,7 +625,7 @@ func TestEnabledTypes_IncludesCustom(t *testing.T) {
 	cfg.Types["disabledcustom"] = disabled
 
 	got := cfg.EnabledTypes()
-	want := []string{"rfc", "adr", "design", "impl", "plan", "investigation", "adapters", "frameworks"}
+	want := []string{"rfc", "adr", "design", "impl", "investigation", "adapters", "frameworks"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("EnabledTypes() = %v, want %v (built-ins registry-order, then custom sorted)", got, want)
 	}

--- a/pkg/doczcore/config/doctype.go
+++ b/pkg/doczcore/config/doctype.go
@@ -134,8 +134,12 @@ var allDocTypes = []DocTypeDef{
 		Name:    "plan",
 		Aliases: nil,
 		DefaultConfig: func() TypeConfig {
+			// Disabled by default: PLAN sits between RFC (proposal) and
+			// IMPL (phased execution), a slot most repos fill with
+			// DESIGN + IMPL instead. Repos that want it set
+			// types.plan.enabled: true.
 			return TypeConfig{
-				Enabled:     true,
+				Enabled:     false,
 				Dir:         "plan",
 				IDPrefix:    "PLAN",
 				IDWidth:     4,

--- a/test/consumer/consumer_v1_test.go
+++ b/test/consumer/consumer_v1_test.go
@@ -159,7 +159,7 @@ func TestExternalConsumerCreatesFromEmbeddedTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading created doc: %v", err)
 	}
-	for _, want := range []string{"id: RFC-0001", "# RFC 0001: Consumer Proof", toc.BeginMarker} {
+	for _, want := range []string{"id: RFC-0001", "# RFC-0001: Consumer Proof", toc.BeginMarker} {
 		if !strings.Contains(string(body), want) {
 			t.Errorf("created doc missing %q", want)
 		}

--- a/testdata/golden/adr.md
+++ b/testdata/golden/adr.md
@@ -5,16 +5,17 @@ status: Proposed
 author: Test Author
 created: 2026-02-22
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# 0001. Test Document
+# ADR-0001: Test Document
 
 <!--toc:start-->
 <!--toc:end-->
 
-## Status
+## Summary
 
-Proposed
+<!-- Brief 2-3 sentence summary of the proposal -->
 
 ## Context
 
@@ -23,6 +24,10 @@ Proposed
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
+
+### Supporting Data
+
+<!-- Data gathered that support the proposed solution. -->
 
 ## Consequences
 

--- a/testdata/golden/design.md
+++ b/testdata/golden/design.md
@@ -5,13 +5,10 @@ status: Draft
 author: Test Author
 created: 2026-02-22
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# DESIGN 0001: Test Document
-
-**Status:** Draft
-**Author:** Test Author
-**Date:** 2026-02-22
+# DESIGN-0001: Test Document
 
 <!--toc:start-->
 <!--toc:end-->

--- a/testdata/golden/impl.md
+++ b/testdata/golden/impl.md
@@ -5,13 +5,10 @@ status: Draft
 author: Test Author
 created: 2026-02-22
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# IMPL 0001: Test Document
-
-**Status:** Draft
-**Author:** Test Author
-**Date:** 2026-02-22
+# IMPL-0001: Test Document
 
 <!--toc:start-->
 <!--toc:end-->
@@ -98,7 +95,7 @@ are checked off and its success criteria are met.
 <!-- Key files that will be created or modified -->
 
 | File | Action | Description |
-|------|--------|-------------|
+| ---- | ------ | ----------- |
 |      | Create |             |
 |      | Modify |             |
 

--- a/testdata/golden/investigation.md
+++ b/testdata/golden/investigation.md
@@ -1,14 +1,14 @@
 ---
-id: {{ .Prefix }}-{{ .Number }}
-title: "{{ .Title }}"
-status: {{ .Status }}
-author: {{ .Author }}
-created: {{ .Date }}
+id: INV-0001
+title: "Test Document"
+status: Open
+author: Test Author
+created: 2026-02-22
 ---
 
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
+# INV-0001: Test Document
 
 <!--toc:start-->
 <!--toc:end-->

--- a/testdata/golden/plan.md
+++ b/testdata/golden/plan.md
@@ -1,14 +1,14 @@
 ---
-id: {{ .Prefix }}-{{ .Number }}
-title: "{{ .Title }}"
-status: {{ .Status }}
-author: {{ .Author }}
-created: {{ .Date }}
+id: PLAN-0001
+title: "Test Document"
+status: Draft
+author: Test Author
+created: 2026-02-22
 ---
 
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
+# PLAN-0001: Test Document
 
 <!--toc:start-->
 <!--toc:end-->

--- a/testdata/golden/rfc.md
+++ b/testdata/golden/rfc.md
@@ -5,13 +5,10 @@ status: Draft
 author: Test Author
 created: 2026-02-22
 ---
+
 <!-- markdownlint-disable-file MD025 MD041 -->
 
-# RFC 0001: Test Document
-
-**Status:** Draft
-**Author:** Test Author
-**Date:** 2026-02-22
+# RFC-0001: Test Document
 
 <!--toc:start-->
 <!--toc:end-->
@@ -22,32 +19,24 @@ created: 2026-02-22
 
 ## Problem Statement
 
-<!-- What problem does this RFC address? Include evidence and impact. -->
+<!-- What problem does this RFC address? Include supporting data, evidence and impact. -->
+
+### Supporting Data
+
+<!-- Data gathered that support the proposed solution. -->
 
 ## Proposed Solution
 
 <!-- High-level description of the proposed approach -->
 
-## Design
-
-<!-- Detailed design including architecture, data flow, APIs, etc. -->
-
 ## Alternatives Considered
 
 <!-- What other approaches were evaluated and why were they rejected? -->
 
-## Implementation Phases
-
-<!-- Break the implementation into phases/milestones -->
-
-### Phase 1: ...
-
-### Phase 2: ...
-
 ## Risks and Mitigations
 
 | Risk | Impact | Likelihood | Mitigation |
-|------|--------|------------|------------|
+| ---- | ------ | ---------- | ---------- |
 |      |        |            |            |
 
 ## Success Criteria


### PR DESCRIPTION
Templates, one config default, and the two design docs for the upcoming `api:` block.

## Templates

All six built-in templates now render their H1 as:

```
# {{ .Prefix }}-{{ .Number }}: {{ .Title }}
```

The heading now matches the frontmatter `id` exactly and tracks a repo's configured `id_prefix`. The previous hardcoded literals (`# RFC {{ .Number }}:`) were wrong for custom types and for any repo that changed `id_prefix`; verified against a scratch repo with `id_prefix: DD` and a custom `frameworks` type.

Also in the templates:

- **Body `**Status:**/**Author:**/**Date:**` block removed.** `docz status set` only mutates frontmatter, so that line silently went stale — 2 of the 30 docs in this repo had already drifted.
- RFC drops `## Design` and `## Implementation Phases` (duplicated the DESIGN and IMPL types).
- ADR `## Status` → `## Summary`; `### Supporting Data` added to ADR and RFC.
- Table delimiters normalized; blank line after frontmatter.

**Golden coverage extended to `plan` and `investigation`**, which previously had none — all six built-ins are now pinned.

## PLAN disabled by default

`plan` sits between RFC (proposal) and IMPL (phased execution), a slot most repos fill with DESIGN + IMPL instead. Zero PLAN docs have been created in this repo.

It stays in the registry and in generated `.docz.yaml`, so enabling it is one boolean:

```
$ docz create plan "Something"
Error: document type "plan" is disabled in configuration
```

This changes `DefaultConfig()` and `EnabledTypes()` output. Both godocs now say so, as does the README. Repos with an explicit `types.plan.enabled: true` — including this one — are unaffected.

## Docs

- **DESIGN-0011** — the `api:` block (`landing_page`, `exclude`, `additional_docs`) for docz-api and docz-site. Ten decisions recorded, zero open questions. The governing rule: the URL path mirrors the `docs_dir` path, and a directory's `README.md` is that directory's page (`docs/impl/README.md` → `/:owner/:repo/impl`). Proposes contract clause R10.
- **INV-0007** — the internals audit behind it. Config is routine, but the feature needs one public addition: a bytes-in H1 extractor, since `wiki.DocTitle` is internal and path-based and `docparse.Headings` excludes H1 by design.
- Two stale body status lines fixed (IMPL-0014, INV-0002).
- DESIGN-0001's four template examples regenerated from the real template files rather than hand transcription — this recovered drift going back to March, including missing markdownlint and ToC markers.
- `.docz.example.yaml` added, `api:` block matching DESIGN-0011 and marked proposed / not yet implemented.

## Verification

`make ci` green. `make test-consumer` caught one stale H1 assertion in `test/consumer/` (separate module, outside root `./...`) — worth remembering that template changes need `make ci`, not just `make test`.

Note: DESIGN-0011's implementation (`APIConfig`, `docparse.Title`) is **not** in this PR — that's the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)