### PR TITLE
chore: dogfood the api block — publish docs pages + contributor guides

### DIFF
--- a/.docz.yaml
+++ b/.docz.yaml
@@ -97,3 +97,11 @@ wiki:
   exclude:
     - templates
     - examples
+
+api:
+  enabled: true # publish non-docz markdown under docs_dir as docz-api pages
+  exclude:
+    - examples # mirrors the wiki exclusion
+  additional_docs:
+    - CONTRIBUTING.md
+    - DEVELOPMENT.md


### PR DESCRIPTION
## Summary

Enables the `v1.2.0` `api:` block on docz itself — the rollout's first real traffic, per docz-api's IMPL-0007 Phase 7 dogfood task:

- `docs/index.md` stays the landing page (the CLI backfill default; cached on the repo row, not published as a page).
- `exclude: [examples]` mirrors the existing wiki exclusion (`templates/` is always excluded).
- Repo-root `CONTRIBUTING.md` and `DEVELOPMENT.md` are published as `additional_docs`.

Once merged, the next docz-api ingest serves these at `GET /api/v1/repos/donaldgifford/docz/pages[/{path}]` and makes them searchable under `source: page`.

## Test plan

- [x] `docz config` resolves clean with the new block (validated against the pinned v1.2.0 loader by docz-api's `doczcontract` R10 tests, which exercise this exact shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)